### PR TITLE
Added configuration of unsafe channels

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -135,6 +135,24 @@ if len(primary):
 else:
     logger.warning("No events found for %s" % pchannel)
 
+# load unsafe channels list
+_unsafe = cp.get('safety', 'unsafe-channels')
+if os.path.isfile(_unsafe):  # from file
+    unsafe = set()
+    with open(_unsafe, 'rb') as f:
+        for c in f.read().rstrip('\n').split('\n'):
+            if c.startswith('%(IFO)s'):
+                unsafe.add(c.replace('%(IFO)s', ifo))
+            elif not c.startswith('%s:' % ifo):
+                unsafe.add('%s:%s' % (ifo, c))
+            else:
+                unsafe.add(c)
+else:  # or from line-seprated list
+    unsafe = set(_unsafe.strip('\n').split('\n'))
+unsafe.add(pchannel)
+cp.set('safety', 'unsafe-channels', '\n'.join(sorted(unsafe)))
+logger.debug("Read list of %d unsafe channels" % len(unsafe))
+
 # load auxiliary triggers
 auxetg = cp.get('auxiliary', 'trigger-generator')
 auxfreq = cp.getfloats('auxiliary', 'frequency-range')
@@ -143,12 +161,19 @@ try:
 except config.configparser.NoOptionError:
     auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo)
 # remove duplicates
-auxchannels = list(set(auxchannels))
-# remove primary
-try:
-    auxchannels.pop(auxchannels.index(pchannel))
-except ValueError:
-    pass
+auxchannels = sorted(set(auxchannels))
+logger.debug("Read list of %d auxiliary channels" % len(auxchannels))
+
+# remove unsafe channels
+nunsafe = 0
+for chan in auxchannels:
+    if chan in unsafe:
+        logger.warning("Auxiliary channel %r identified as unsafe and has "
+                       "been removed" % chan)
+        auxchannels.pop(auxchannels.index(chan))
+        nunsafe += 1
+logger.debug("%d auxiliary channels identified as unsafe" % nunsafe)
+
 naux = len(auxchannels)
 logger.info("Identified %d auxiliary channels to process" % naux)
 

--- a/hveto/config.py
+++ b/hveto/config.py
@@ -53,6 +53,14 @@ class HvetoConfigParser(configparser.ConfigParser):
             'trigger-generator': 'Omicron',
             'frequency-range': (30, 2048),
         },
+        'safety': {
+            'unsafe-channels': ['%(IFO)s:GDS-CALIB_STRAIN',
+                                '%(IFO)s:LDAS-STRAIN',
+                                '%(IFO)s:CAL-DELTAL_EXTERNAL_DQ',
+                                '%(IFO)s:DER_DATA_H',
+                                '%(IFO)s:h_4096Hz',
+                                '%(IFO)s:h_16384Hz'],
+        }
     }
 
     def __init__(self, ifo=None, defaults=dict(), **kwargs):
@@ -65,7 +73,9 @@ class HvetoConfigParser(configparser.ConfigParser):
         for section in self.HVETO_DEFAULTS:
             self.add_section(section)
             for key, val in self.HVETO_DEFAULTS[section].iteritems():
-                if isinstance(val, tuple):
+                if key.endswith('channels') and isinstance(val, (tuple, list)):
+                    self.set(section, key, '\n'.join(list(val)))
+                elif isinstance(val, tuple):
                     self.set(section, key, ', '.join(map(str, val)))
                 else:
                     self.set(section, key, str(val))


### PR DESCRIPTION
This PR introduces parsing of unsafe channels via a new `[safety]` config section:

```ini
[safety]
unsafe-channels =
    channel1
    channel1
```

The value of `unsafe-channels` can either be a line-separated list, or the path to a file contain a single column of channels that are unsafe.