### PR TITLE
Read primary triggers from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - pip install -q --upgrade pip
 
 install:
+  - pip install `grep "/glue-" requirements.txt`  # install glue first
   - pip install ${PRE} -r requirements.txt
 
 script:

--- a/bin/hveto
+++ b/bin/hveto
@@ -143,8 +143,10 @@ pchannel = cp.get('primary', 'channel')
 petg = cp.get('primary', 'trigger-generator')
 psnr = cp.getfloat('primary', 'snr-threshold')
 pfreq = cp.getfloats('primary', 'frequency-range')
+ptrigfind = dict((key.split('-', 1)[1], val) for (key, val) in
+                 cp.items('primary') if key.startswith('trigfind-'))
 primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
-                       cache=cache)
+                       cache=cache, **ptrigfind)
 if len(primary):
     logger.info("Read %d events for %s" % (len(primary), pchannel))
 else:

--- a/bin/hveto
+++ b/bin/hveto
@@ -38,6 +38,8 @@ except ImportError:  # python 2.x
 from matplotlib import use
 use('agg')
 
+from glue.lal import Cache
+
 from gwpy.time import to_gps
 from gwpy.segments import (DataQualityFlag, DataQualityDict)
 
@@ -67,6 +69,9 @@ parser.add_argument('-i', '--ifo', default=IFO, required=IFO is None,
 parser.add_argument('-j', '--nproc', type=int, default=1,
                     help='number of cores to use for multiprocessing, '
                          'default: %(default)s')
+parser.add_argument('-p', '--primary-cache', action='append', default=[],
+                    type=os.path.expanduser,
+                    help='path for cache containing primary channel files')
 
 pout = parser.add_argument_group('Output options')
 pout.add_argument('-o', '--output-directory', default=os.curdir,
@@ -127,12 +132,19 @@ segments[analysis.name] = analysis
 
 # -- load triggers ------------------------------------------------------------
 
+# read primary cache
+if args.primary_cache:
+    cache = Cache.fromfilenames(args.primary_cache)
+else:
+    cache = None
+
 # load primary triggers
 pchannel = cp.get('primary', 'channel')
 petg = cp.get('primary', 'trigger-generator')
 psnr = cp.getfloat('primary', 'snr-threshold')
 pfreq = cp.getfloats('primary', 'frequency-range')
-primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq)
+primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
+                       cache=cache)
 if len(primary):
     logger.info("Read %d events for %s" % (len(primary), pchannel))
 else:
@@ -245,7 +257,15 @@ significance = 1e9
 
 pevents = [primary]
 pvetoed = []
+
+# get plot parameters based on table
 statlabel = 'Signal-to-noise ratio (SNR)'
+if petg in ['daily-cbc']:
+    fparam = 'mchirp'
+    flabel = r'Chirp mass [M$_{\odot}$]'
+else:
+    fparam = 'frequency'
+    flabel = r'Frequency [Hz]'
 
 rounds = []
 round = core.HvetoRound(1)
@@ -404,29 +424,35 @@ cum. deadtime :   %s""" % (
     round.plots.append(png)
 
     # snr versus frequency
-    png = pngname % 'SNR_FREQUENCY'
+    png = pngname % 'SNR_%s' % fparam.upper()
     plot.veto_scatter(
-        png, before, vetoed, x='frequency', y='snr', label1=beforel,
-        label2=vetoedl, xlabel='Frequency [Hz]', ylabel=statlabel,
+        png, before, vetoed, x=fparam, y='snr', label1=beforel,
+        label2=vetoedl, xlabel=flabel, ylabel=statlabel,
         title=title, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
     round.plots.append(png)
 
     # frequency versus time coloured by SNR
-    png = pngname % 'FREQUENCY_TIME'
+    png = pngname % '%s_TIME' % fparam.upper()
     plot.veto_scatter(
-        png, before, vetoed, x='time', y='frequency', color='snr',
-        label1=None, label2=None, ylabel='Frequency [Hz]',
+        png, before, vetoed, x='time', y=fparam, color='snr',
+        label1=None, label2=None, ylabel=flabel,
         clabel=statlabel, clim=[3, 100], cmap='YlGnBu',
         epoch=start, xlim=[start, end], title=title, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
     round.plots.append(png)
 
     # aux used versus frequency
+    if winner.events.dtype == vetoed.dtype:
+        y = fparam
+        ylabel = flabel
+    else:
+        y = 'snr'
+        ylabel = statlabel
     png = pngname % 'USED_FREQUENCY_TIME'
     plot.veto_scatter(
-        png, winner.events, vetoed, x='time', y='frequency', label1=usedl,
-        label2=vetoedl, ylabel='Frequency [Hz]',
+        png, winner.events, vetoed, x='time', y=y, label1=usedl,
+        label2=vetoedl, ylabel=ylabel,
         epoch=start, xlim=[start, end], title=title, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
     round.plots.append(png)
@@ -494,12 +520,12 @@ plots.append(png)
 logger.debug("Figure written to %s" % png)
 
 # frequency versus time
-png = pngname % 'FREQUENCY_TIME'
+png = pngname % '%s_TIME' % fparam.upper()
 label2 = ['After round %d' % r.n for r in rounds]
 plot.veto_scatter(
     png, pevents[0], pvetoed,
     label1='Before round 1', label2=label2, title=title,
-    subtitle=subtitle, ylabel='Frequency [Hz]', x='time', y='frequency',
+    subtitle=subtitle, ylabel=flabel, x='time', y=fparam,
     epoch=start, xlim=[start, end])
 plots.append(png)
 logger.debug("Figure written to %s" % png)

--- a/hveto/config.py
+++ b/hveto/config.py
@@ -88,6 +88,23 @@ Each of the below sections lists the valid options and a description of what the
    for all interferometers, with the correct two-character prefix being
    inserted automatically at run time.
 
+.. note::
+
+   As well as the above, users can specify arguments to be used when
+   automatically discovering triggers. Any option that begins ``trigfind-``
+   will be passed to the `trigfind.find_trigger_urls` function as a keyword
+   argument.
+
+   Specifically, to specify the specific run associated with the ``daily-cbc``
+   event generator, you can give
+
+   .. code-block::
+
+      [primary]
+      trigger-generator = daily-cbc
+      trigfind-run = bbh_gds
+      trigfind-filetag = 16SEC_CLUSTERED
+
 [auxiliary]
 -----------
 
@@ -112,6 +129,11 @@ Each of the below sections lists the valid options and a description of what the
        %(IFO)s:ISI-ITMX_ST2_BLND_X_GS13_CUR_IN1_DQ
        %(IFO)s:ASC-REFL_A_RF9_I_YAW_OUT_DQ
        %(IFO)s:ASC-AS_A_RF45_Q_YAW_OUT_DQ
+
+.. note::
+
+   As with the ``[primary]`` section, users can specify ``trigfind-``
+   arguments to customise trigger-file discovery.
 
 [segments]
 ----------

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -114,6 +114,7 @@ def veto_scatter(
             colorargs['vmax'] = clim[1]
             if clog:
                 colorargs['norm'] = LogNorm(vmin=clim[0], vmax=clim[1])
+        a = a.copy()
         a.sort(order=color)
         m = ax.scatter(a[x], a[y], c=a[color], label=label1, **colorargs)
         # add colorbar

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -115,9 +115,7 @@ def veto_scatter(
             if clog:
                 colorargs['norm'] = LogNorm(vmin=clim[0], vmax=clim[1])
         a.sort(order=color)
-        a = a[::-1]
-        m = ax.scatter(a[x], a[y], c=a[color], label=label1,
-                       **colorargs)
+        m = ax.scatter(a[x], a[y], c=a[color], label=label1, **colorargs)
         # add colorbar
         plot.add_colorbar(mappable=m, ax=ax, cmap=cmap, label=clabel)
         # unsort them

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -105,7 +105,7 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
     # filter
     if snr is not None:
         recarray = recarray[recarray['snr'] >= snr]
-    if frange is not None:
+    if tablename.endswith('_burst') and frange is not None:
         recarray = recarray[
             (recarray['frequency'] >= frange[0]) &
             (recarray['frequency'] < frange[1])]

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -73,6 +73,7 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
 
     # read cache
     trigs = lsctables.New(Table, columns=columns)
+    cache.sort(key=lambda x: x.segment[0])
     for segment in segments:
         if len(cache.sieve(segment=segment)):
             if tablename.endswith('_inspiral'):
@@ -102,6 +103,8 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
             recarray, 'time', times, times.dtype)
         recarray = recfunctions.rec_drop_fields(recarray, tcols)
         columns = ['time'] + columns[2:]
+        recarray.sort(order='time')
+
     # filter
     if snr is not None:
         recarray = recarray[recarray['snr'] >= snr]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib >= 1.5
 scipy
 gitpython
 jinja2
-https://github.com/ligovirgo/trigfind/archive/v0.1.tar.gz
+https://github.com/ligovirgo/trigfind/archive/v0.2.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 gwpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib >= 1.5
 scipy
 gitpython
 jinja2
-https://github.com/ligovirgo/trigfind/archive/v0.2.tar.gz
+https://github.com/ligovirgo/trigfind/archive/v0.2.1.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 gwpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ matplotlib >= 1.5
 scipy
 gitpython
 jinja2
+https://github.com/ligovirgo/trigfind/archive/v0.1.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 gwpy


### PR DESCRIPTION
This PR fixes #8 (mostly) by implementing a `--primary-cache` option for the `hveto` executable, allowing the user to manually specify the triggers as input.

Also included are

- use [trigfind](//github.com/ligovirgo/trigfind) for automatic file discovery, this allows users to specify `omicron` or `kw` as the aux ETG, and those plus `dmt-omega` and `daily-cbc` as the primary ETG
- fixed a couple of bugs