### PR TITLE
Read events from --auxiliary-cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 script:
   - pip install coveralls
-  - coverage run --omit="hveto/tests/*,hveto/_version.py" ./setup.py test
+  - coverage run --source=hveto --omit="hveto/tests/*,hveto/_version.py" ./setup.py test
 
 after_success:
   - coveralls

--- a/bin/hveto
+++ b/bin/hveto
@@ -79,8 +79,15 @@ parser.add_argument('-j', '--nproc', type=int, default=1,
                     help='number of cores to use for multiprocessing, '
                          'default: %(default)s')
 parser.add_argument('-p', '--primary-cache', action='append', default=[],
-                    type=os.path.expanduser,
+                    type=abs_path,
                     help='path for cache containing primary channel files')
+parser.add_argument('-a', '--auxiliary-cache', action='append', default=[],
+                    type=abs_path,
+                    help='path for cache containing auxiliary channel files, '
+                         'files contained must be T050017-compliant with the '
+                         'channel name as the leading name parts, e.g. '
+                         '\'L1-GDS_CALIB_STRAIN_<tag>-<start>-<duration>.'
+                         '<ext>\' for L1:GDS-CALIB_STRAIN triggers')
 
 pout = parser.add_argument_group('Output options')
 pout.add_argument('-o', '--output-directory', default=os.curdir,
@@ -185,13 +192,19 @@ unsafe.add(pchannel)
 cp.set('safety', 'unsafe-channels', '\n'.join(sorted(unsafe)))
 logger.debug("Read list of %d unsafe channels" % len(unsafe))
 
+if args.auxiliary_cache:
+    cache = Cache.fromfilenames(args.auxiliary_cache)
+else:
+    cache = None
+
 # load auxiliary triggers
 auxetg = cp.get('auxiliary', 'trigger-generator')
 auxfreq = cp.getfloats('auxiliary', 'frequency-range')
 try:
     auxchannels = cp.get('auxiliary', 'channels').strip('\n').split('\n')
 except config.configparser.NoOptionError:
-    auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo)
+    auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo,
+                                          cache=cache)
 # remove duplicates
 auxchannels = sorted(set(auxchannels))
 logger.debug("Read list of %d auxiliary channels" % len(auxchannels))
@@ -213,10 +226,16 @@ logger.info("Reading triggers for aux channels...")
 counter = multiprocessing.Value('i', 0)
 
 def _get_aux_triggers(channel):
+    if cache is None:
+        auxcache = None
+    else:
+        ifo, name = channel.split(':')
+        desc = name.replace('-', '_')
+        auxcache = cache.sieve(ifos=ifo, description='%s*' % desc)
     # get triggers
     try:
         trigs = get_triggers(channel, auxetg, analysis.active, snr=minsnr,
-                             frange=auxfreq)
+                             frange=auxfreq, cache=auxcache)
     # catch error and continue
     except ValueError as e:
         warnings.warn('%s: %s' % (type(e).__name__, str(e)))

--- a/hveto/tests/test_triggers.py
+++ b/hveto/tests/test_triggers.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Joshua Smith (2016-)
+#
+# This file is part of the hveto python package.
+#
+# hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hveto.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `hveto.triggers`
+"""
+
+from glue.lal import Cache
+
+from hveto import triggers
+
+from common import unittest
+
+AUX_FILES = {
+    'L1:GDS-CALIB_STRAIN': 'L1-GDS_CALIB_STRAIN_OMICRON-12345-67890.xml.gz',
+    'H1:SUS-BS_M1_MASTER_OUT_F2_DQ_0_DAC':
+        'H1-SUS_BS_M1_MASTER_OUT_F2_DQ_0_DAC-1126252143-22179.xml.gz',
+}
+
+
+class TriggersTestCase(unittest.TestCase):
+
+    def test_aux_channels_from_cache(self):
+        cache = Cache.from_urls(AUX_FILES.values())
+        channels = triggers.find_auxiliary_channels('omicron', None, None,
+                                                    cache=cache)
+        self.assertListEqual(channels, sorted(AUX_FILES.keys()))

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -117,19 +117,25 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
 
 re_delim = re.compile('[_-]')
 
-def find_auxiliary_channels(etg, gps='*', ifo='*'):
+def find_auxiliary_channels(etg, gps='*', ifo='*', cache=None):
     """Find all auxiliary channels processed by a given ETG
     """
-    channels = glob.glob(os.path.join(
-        trigfind.TRIGFIND_BASE_PATH, '*', ifo, '*', str(gps)[:5]))
     out = set()
-    stub = '_%s' % etg.lower()
-    for path in channels:
-        path = os.path.split(path)[0]
-        if not path.lower().endswith('_%s' % etg.lower()):
-            continue
-        ifo, name = path[:-len(stub)].rsplit(os.path.sep)[-2:]
-        out.add('%s:%s' % (ifo, name))
+    if cache is not None:
+        for e in cache:
+            ifo = e.observatory
+            name = e.description
+            out.add('%s:%s' % (ifo, name.replace('_', '-', 1)))
+    else:
+        channels = glob.glob(os.path.join(
+            trigfind.TRIGFIND_BASE_PATH, '*', ifo, '*', str(gps)[:5]))
+        stub = '_%s' % etg.lower()
+        for path in channels:
+            path = os.path.split(path)[0]
+            if not path.lower().endswith('_%s' % etg.lower()):
+                continue
+            ifo, name = path[:-len(stub)].rsplit(os.path.sep)[-2:]
+            out.add('%s:%s' % (ifo, name))
     return sorted(out)
 
 

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -119,6 +119,27 @@ re_delim = re.compile('[_-]')
 
 def find_auxiliary_channels(etg, gps='*', ifo='*', cache=None):
     """Find all auxiliary channels processed by a given ETG
+
+    If `cache=None` is given (default), the channels are parsed from the
+    ETG archive under ``/home/detchar/triggers``. Otherwise, the channel
+    names are parsed from the files in the `cache`, assuming they follow
+    the T050017 file-naming convention.
+
+    Parameters
+    ----------
+    etg : `str`
+        name of the trigger generator
+    gps : `int`, optional
+        GPS reference time at which to find channels
+    ifo : `str`, optional
+        interferometer prefix for which to find channels
+    cache : `~glue.lal.Cache`, optional
+        `Cache` of files from which to parse channels
+
+    Returns
+    -------
+    channels : `list` of `str`
+        the names of all available auxiliary channels
     """
     out = set()
     if cache is not None:

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -125,7 +125,10 @@ def find_auxiliary_channels(etg, gps='*', ifo='*', cache=None):
         for e in cache:
             ifo = e.observatory
             name = e.description
-            out.add('%s:%s' % (ifo, name.replace('_', '-', 1)))
+            channel = '%s:%s' % (ifo, name.replace('_', '-', 1))
+            if channel.lower().endswith(etg.lower()):
+                channel = channel[:-len(etg)]
+            out.add(channel.rstrip('_'))
     else:
         channels = glob.glob(os.path.join(
             '/home/detchar/triggers', '*', ifo, '*', str(gps)[:5]))

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -128,7 +128,7 @@ def find_auxiliary_channels(etg, gps='*', ifo='*', cache=None):
             out.add('%s:%s' % (ifo, name.replace('_', '-', 1)))
     else:
         channels = glob.glob(os.path.join(
-            trigfind.TRIGFIND_BASE_PATH, '*', ifo, '*', str(gps)[:5]))
+            '/home/detchar/triggers', '*', ifo, '*', str(gps)[:5]))
         stub = '_%s' % etg.lower()
         for path in channels:
             path = os.path.split(path)[0]


### PR DESCRIPTION
This PR implements the `--auxiliary-cache` option for the `hveto` executable, allowing events to be read from arbitrary files. The mapping between channels and the files in the cache is simple, requiring the following

- only one channel per file
- T050017-format file name with `<ifo>:<system>-<subsytem>_<tag>` in the channel name mapping to `<ifo>-<system>_<subsystem>_<tag>*` in the file name, e.g. files for `L1:GDS-CALIB_STRAIN` would be read from `L1-GDS_CALIB_STRAIN_OMICRON-xxx-xxx.xml.gz`

Fixes #8 (along with #21)
Fixes #18, compare [original run](https://ldas-jobs.ligo-wa.caltech.edu/~hveto/daily/201509/20150914/H1-omicron_BOTH-1126224017-86400-DAC/) to [new run](https://ldas-jobs.ligo-wa.caltech.edu/~duncan.macleod/hveto/testing/dac-triggers/20150914/).