### PR TITLE
Added extended documentation of hveto command-line options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
       - gfortran  # scipy
       - libblas-dev  # scipy
       - liblapack-dev  # scipy
-      - python-m2crypto  # glue
+      - swig  # m2crypto
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
 script:
   - pip install coveralls
   - coverage run --omit="hveto/tests/*,hveto/_version.py" ./setup.py test
+  - coverage run --append --source=hveto --omit="hveto/tests/*,hveto/_version.py" `which hveto` --help
 
 after_success:
   - coveralls

--- a/docs/command-line/index.rst
+++ b/docs/command-line/index.rst
@@ -1,0 +1,77 @@
+.. _command-line:
+
+#####################################
+Running ``hveto`` on the command line
+#####################################
+
+As described on the home page, the main interface to the hveto algorithm is the command-line executable ``hveto``.
+
+Basic instructions
+==================
+
+Basic instructions on running ``hveto`` can be gained by looking at the ``--help`` menu:
+
+.. command-output:: hveto --help
+
+Detailed instructions
+=====================
+
+A few of the command-line options require special formatting, use the reference below for more detailed info.
+
+``gpsstart`` and ``gpsend``
+---------------------------
+
+Each of the required GPS start and stop times can be given as GPS integers, or as date strings, e.g.
+
+.. code-block:: bash
+
+   hveto 1135641617 1135728017 ...
+
+will produce the same analysis as
+
+.. code-block:: bash
+
+   hveto "Jan 1 2016" "Jan 2 2016" ...
+
+.. note::
+
+   The quote marks used in the date string example are important so that the shell passes them to ``python`` as a single argument
+
+   
+
+``-j/--nproc``
+--------------
+
+The majority of the processing time for ``hveto`` is taken up by two things
+
+- reading event files for the auxiliary channels
+- determining the most-significant channel for a given round
+
+Each of these can be sped up by using multiple CPUs available on the host machine by supplying ``--nproc X`` where X is any integer.
+
+.. warning::
+
+   No restrictions are placed on the number of parallel processes that can be given on the command line, users should be aware that using too-high a number could overload the machine, or otherwise cause problems for themselves and other users.
+
+   You can check how many processors are available on the machine with the following unix command
+
+   .. code-block:: bash
+
+      cat /proc/cpuinfo | grep processor | wc -l
+
+``-p/--primary-cache``
+----------------------
+
+This should receive a LAL-format cache file (see :mod:`glue.lal` for details)
+
+``-a/--auxiliary-cache``
+------------------------
+
+This should receive a LAL-format cache file (similarly to ``--primary-cache``), but with a specific format:
+
+- each contained trigger file should contain events for only a single channel
+- the contained files should map to their channel as follows; if a channel is named ``X1:SYS-SUBSYS_NAME``, each filename should start ``X1-SYS_SUBSYS_NAME`` according to the `T050017 <https://dcc.ligo.org/LIGO-T050017>`_ convention. Additional underscore-delimited components can be given, but will not be used to map to the channel.
+
+.. note::
+
+   If the ``channels`` option is not given in the ``[auxiliary]`` section of the configuration, it will be populated from the unique list of channels parsed as above from the ``--auxiliary-cache``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
     'numpydoc',
+    'sphinxcontrib.programoutput',
+    'sphinxcontrib.epydoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -294,6 +296,7 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
+# -- Extensions -----------------------------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
@@ -302,4 +305,9 @@ intersphinx_mapping = {
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.sourceforge.net/', None),
     'gwpy': ('http://gwpy.github.io/docs/latest/', None),
+}
+
+# Epydoc extension config for GLUE
+epydoc_mapping = {
+    'http://software.ligo.org/docs/glue/': [r'glue(\.|$)'],
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,8 @@ For a full list of command-line argument and options, run
 
    $ hveto --help
 
+For more details see :ref:`command-line`.
+
 Package documentation
 ---------------------
 
@@ -47,6 +49,7 @@ Please consult these pages for more details on using Hveto:
 .. toctree::
    :maxdepth: 1
 
+   command-line/index
    api/hveto.config
 
 Indices and tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ matplotlib >= 1.5
 scipy
 gitpython
 jinja2
+pykerberos
+m2crypto
+python-cjson
 https://github.com/ligovirgo/trigfind/archive/v0.2.1.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,13 @@ tests_require = [
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')
 extras_require = {
-    'doc': ['sphinx', 'numpydoc', 'sphinx_rtd_theme'],
+    'doc': [
+        'sphinx',
+        'numpydoc',
+        'sphinx_rtd_theme',
+        'sphinxcontrib_programoutput',
+        'sphinxcontrib_epydoc',
+    ],
 }
 
 # -- run setup ----------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a new page on the HTML documentation, giving detailed descriptions of the command-line options for `hveto` that would be too verbose for the normal `--help` message.