### PR TITLE
Handle trigfind ValueError as a warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pip install .
 
 script:
-  - pip install coveralls
+  - pip install ${PRE} unittest2 coveralls "pytest>=2.8"
   - coverage run --source=hveto --omit="hveto/tests/*,hveto/_version.py" ./setup.py test
   - coverage run --append --source=hveto --omit="hveto/tests/*,hveto/_version.py" `which hveto` --help
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,9 @@ matrix:
 
 before_install:
   - pip install -q --upgrade pip
+  - pip install ${PRE} -r requirements.txt
 
 install:
-  - pip install `grep "/glue-" requirements.txt`  # install glue first
-  - pip install ${PRE} -r requirements.txt
   - pip install .
 
 script:

--- a/bin/hveto
+++ b/bin/hveto
@@ -150,29 +150,25 @@ windows = cp.getfloats('hveto', 'time-windows')
 segments = DataQualityDict()
 segments[analysis.name] = analysis
 
-# -- load triggers ------------------------------------------------------------
+# -- load channels ------------------------------------------------------------
 
-# read primary cache
-if args.primary_cache:
-    cache = Cache.fromfilenames(args.primary_cache)
-else:
-    cache = None
-
-# load primary triggers
+# get primary channel name
 pchannel = cp.get('primary', 'channel')
-petg = cp.get('primary', 'trigger-generator')
-psnr = cp.getfloat('primary', 'snr-threshold')
-pfreq = cp.getfloats('primary', 'frequency-range')
-ptrigfind = dict((key.split('-', 1)[1], val) for (key, val) in
-                 cp.items('primary') if key.startswith('trigfind-'))
-primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
-                       cache=cache, **ptrigfind)
-if len(primary):
-    logger.info("Read %d events for %s" % (len(primary), pchannel))
+
+# read auxiliary cache
+if args.auxiliary_cache:
+    acache = Cache.fromfilenames(args.auxiliary_cache)
 else:
-    message = "No events found for %r in %d seconds of livetime" % (
-       pchannel, livetime)
-    logger.critical(message)
+    acache = None
+
+# load auxiliary channels
+auxetg = cp.get('auxiliary', 'trigger-generator')
+auxfreq = cp.getfloats('auxiliary', 'frequency-range')
+try:
+    auxchannels = cp.get('auxiliary', 'channels').strip('\n').split('\n')
+except config.configparser.NoOptionError:
+    auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo,
+                                          cache=acache)
 
 # load unsafe channels list
 _unsafe = cp.get('safety', 'unsafe-channels')
@@ -192,19 +188,6 @@ unsafe.add(pchannel)
 cp.set('safety', 'unsafe-channels', '\n'.join(sorted(unsafe)))
 logger.debug("Read list of %d unsafe channels" % len(unsafe))
 
-if args.auxiliary_cache:
-    cache = Cache.fromfilenames(args.auxiliary_cache)
-else:
-    cache = None
-
-# load auxiliary triggers
-auxetg = cp.get('auxiliary', 'trigger-generator')
-auxfreq = cp.getfloats('auxiliary', 'frequency-range')
-try:
-    auxchannels = cp.get('auxiliary', 'channels').strip('\n').split('\n')
-except config.configparser.NoOptionError:
-    auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo,
-                                          cache=cache)
 # remove duplicates
 auxchannels = sorted(set(auxchannels))
 logger.debug("Read list of %d auxiliary channels" % len(auxchannels))
@@ -218,20 +201,77 @@ for i in xrange(len(auxchannels) -1, -1, -1):
         auxchannels.pop(i)
         nunsafe += 1
 logger.debug("%d auxiliary channels identified as unsafe" % nunsafe)
-
 naux = len(auxchannels)
 logger.info("Identified %d auxiliary channels to process" % naux)
+
+# record INI file in output HTML directory
+inifile = '%s-HVETO_CONFIGURATION-%d-%d.ini' % (ifo, start, duration)
+if os.path.isfile(inifile) and any(
+        os.path.samefile(inifile, x) for x in args.config_file):
+    logger.debug("Cannot write INI file to %s, file was given as input")
+else:
+    with open(inifile, 'w') as f:
+        cp.write(f)
+    logger.info("Configuration recorded as %s" % inifile)
+htmlv['config'] = inifile
+
+# -- load primary triggers ----------------------------------------------------
+
+# read primary cache
+if args.primary_cache:
+    pcache = Cache.fromfilenames(args.primary_cache)
+else:
+    pcache = None
+
+# load primary triggers
+petg = cp.get('primary', 'trigger-generator')
+psnr = cp.getfloat('primary', 'snr-threshold')
+pfreq = cp.getfloats('primary', 'frequency-range')
+ptrigfind = dict((key.split('-', 1)[1], val) for (key, val) in
+                 cp.items('primary') if key.startswith('trigfind-'))
+primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
+                       cache=pcache, **ptrigfind)
+
+if len(primary):
+    logger.info("Read %d events for %s" % (len(primary), pchannel))
+else:
+    message = "No events found for %r in %d seconds of livetime" % (
+       pchannel, livetime)
+    logger.critical(message)
+
+# -- bail out early -----------------------------------------------------------
+# the bail out is done here so that we can at least generate the eventual
+# configuration file, mainly for HTML purposes
+
+# no segments
+if livetime == 0:
+    message = ("No active segments found for analysis flag %r in interval "
+               "[%d, %d)" % (aflag, start, end))
+    logger.critical(message)
+    index = html.write_null_page(ifo, start, end, message, context='info',
+                                 **htmlv)
+    logger.info("HTML report written to %s" % index)
+    sys.exit(0)
+
+# no primary triggers
+if primary.size == 0:
+    index = html.write_null_page(ifo, start, end, message, context='danger',
+                                 **htmlv)
+    logger.info("HTML report written to %s" % index)
+    sys.exit(0)
+
+# -- load auxiliary triggers --------------------------------------------------
 
 logger.info("Reading triggers for aux channels...")
 counter = multiprocessing.Value('i', 0)
 
 def _get_aux_triggers(channel):
-    if cache is None:
+    if acache is None:
         auxcache = None
     else:
         ifo, name = channel.split(':')
         desc = name.replace('-', '_')
-        auxcache = cache.sieve(ifos=ifo, description='%s*' % desc)
+        auxcache = acache.sieve(ifos=ifo, description='%s*' % desc)
     # get triggers
     try:
         trigs = get_triggers(channel, auxetg, analysis.active, snr=minsnr,
@@ -275,39 +315,6 @@ with open(chanfile, 'w') as f:
     for chan in auxchannels:
         print(chan, file=f)
 logger.info("Recorded list of valid auxiliary channels in %s" % chanfile)
-cp.set('auxiliary', 'channels', '\n\t%s' % '\n\t'.join(auxchannels))
-
-inifile = '%s-HVETO_CONFIGURATION-%d-%d.ini' % (ifo, start, duration)
-if os.path.isfile(inifile) and any(
-        os.path.samefile(inifile, x) for x in args.config_file):
-    logger.debug("Cannot write INI file to %s, file was given as input")
-else:
-    with open(inifile, 'w') as f:
-        cp.write(f)
-    logger.info("Configuration recorded as %s" % inifile)
-htmlv['config'] = inifile
-
-# -- bail out early -----------------------------------------------------------
-# the bail out is done here so that we can at least generate the eventual
-# configuration file, mainly for HTML purposes
-
-# no segments
-if livetime == 0:
-    message = ("No active segments found for analysis flag %r in interval "
-               "[%d, %d)" % (aflag, start, end))
-    logger.critical(message)
-    index = html.write_null_page(ifo, start, end, message, context='info',
-                                 **htmlv)
-    logger.info("HTML report written to %s" % index)
-    sys.exit(0)
-
-# no primary triggers
-if primary.size == 0:
-    index = html.write_null_page(ifo, start, end, message, context='danger',
-                                 **htmlv)
-    logger.info("HTML report written to %s" % index)
-    sys.exit(0)
-
 
 # -- execute hveto analysis ---------------------------------------------------
 

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -56,7 +56,11 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
     """Get triggers for the given channel
     """
     # get table from etg
-    Table = TABLE[etg.lower()]
+    try:
+        Table = TABLE[etg.lower()]
+    except KeyError as e:
+        e.args = ('Unknown ETG %r, cannot map to LIGO_LW Table class' % etg,)
+        raise
     tablename = strip_table_name(Table.tableName)
     # get default columns for this table
     if columns is None:

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -22,6 +22,7 @@
 import glob
 import os.path
 import re
+import warnings
 
 import numpy
 from numpy.lib import recfunctions
@@ -68,8 +69,14 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
     if cache is None:
         cache = Cache()
         for start, end in segments:
-            cache.extend(trigfind.find_trigger_urls(channel, etg, start, end,
-                                                    **kwargs))
+            try:
+                cache.extend(trigfind.find_trigger_urls(channel, etg, start,
+                                                        end, **kwargs))
+            except ValueError as e:
+                if str(e).lower().startswith('no channel-level directory'):
+                    warnings.warn(str(e))
+                else:
+                    raise
 
     # read cache
     trigs = lsctables.New(Table, columns=columns)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ jinja2
 pykerberos
 m2crypto
 python-cjson
-https://github.com/ligovirgo/trigfind/archive/v0.2.1.tar.gz
+https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 gwpy


### PR DESCRIPTION
This PR modifies `triggers.get_triggers` to catch the `ValueError` raised from `trigfind.find_trigger_urls` if a channel-level directory is not found for a given channel (fixes #29).

Also, I re-jigged the order of trigger reading in the main `hveto` executable, mainly to clean up when the program bails out if it reads no events. This has no effect on the algorithm, or its output, under normal circumstances.