### PR TITLE
Improved layout of the significance drop plot

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -388,7 +388,7 @@ while True:
     #   only now do we actually have the new data to calculate significance
     #   drop
     if round.n > 1:
-        png = pngname % 'SIG_DROP'
+        png = (pngname % 'SIG_DROP').replace('.png', '.svg')
         plot.significance_drop(png, oldsignificances, newsignificances,
                                title=title, subtitle=subtitle)
         logger.debug("Figure written to %s" % png)

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -382,8 +382,12 @@ def fancybox_img(img, linkparams=dict(), **params):
         'alt': os.path.basename(img),
         'class_': 'img-responsive',
     }
+    if img.endswith('.svg') and os.path.isfile(img.replace('.svg', '.png')):
+        imgparams['src'] = img.replace('.svg', '.png')
+    else:
+        imgparams['src'] = img
     imgparams.update(params)
-    page.img(src=img, **imgparams)
+    page.img(**imgparams)
     page.a.close()
     return str(page)
 

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -277,6 +277,8 @@ def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
             x = l.get_xdata()[1]
             if x < xthresh:
                 ha = 'left'
+            elif x > (len(channels) - xthresh):
+                ha ='right'
             else:
                 ha = 'center'
             y = l.get_ydata()[0] + yoffset

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -141,7 +141,7 @@ def veto_scatter(
     _finalize_plot(plot, ax, outfile, **axargs)
 
 
-def _finalize_plot(plot, ax, outfile, bbox_inches=None, **axargs):
+def _finalize_plot(plot, ax, outfile, bbox_inches=None, close=True, **axargs):
     xlim = axargs.pop('xlim', None)
     ylim = axargs.pop('ylim', None)
     # set title and subtitle
@@ -170,7 +170,8 @@ def _finalize_plot(plot, ax, outfile, bbox_inches=None, **axargs):
         plot.add_colorbar(ax=ax, visible=False)
     # save and close
     plot.save(outfile, bbox_inches=bbox_inches)
-    plot.close()
+    if close:
+        plot.close()
 
 
 def significance_drop(outfile, old, new, **kwargs):

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -187,8 +187,12 @@ def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
     if show_channel_names:
         plot.subplots_adjust(bottom=.4)
 
+    winner = sorted(old.items(), key=lambda x: x[1])[-1][0]
+
     for i, c in enumerate(channels):
-        if old[c] > new[c]:
+        if c == winner:
+            color = 'orange'
+        elif old[c] > new[c]:
             color = 'dodgerblue'
         else:
             color = 'red'

--- a/hveto/tests/test_plot.py
+++ b/hveto/tests/test_plot.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Joshua Smith (2016-)
+#
+# This file is part of the hveto python package.
+#
+# hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hveto.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `hveto.plot`
+"""
+
+import os
+import tempfile
+
+from numpy import random
+
+from hveto import plot
+
+from common import unittest
+
+
+class PlotTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tempfileid, self.tempfile = tempfile.mkstemp(suffix='.png')
+
+    def tearDown(self):
+        if os.path.isfile(self.tempfile):
+            os.remove(self.tempfile)
+
+    def test_drop_plot(self):
+        # this test just makes sure the drop plot code runs end-to-end
+        for x in [10, 50, 200]:
+            channels = ['X1:TEST-%d' % i for i in range(x)]
+            old = dict(zip(channels, random.normal(size=x)))
+            new = dict(zip(channels, random.normal(size=x)))
+            plot.significance_drop(self.tempfile, old, new)
+            svg = self.tempfile.replace('.png', '.svg')
+            try:
+                plot.significance_drop(svg, old, new)
+            finally:
+                if os.path.isfile(svg):
+                    os.remove(svg)

--- a/hveto/tests/test_plot.py
+++ b/hveto/tests/test_plot.py
@@ -22,6 +22,9 @@
 import os
 import tempfile
 
+from matplotlib import use
+use('agg')
+
 from numpy import random
 
 from hveto import plot

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 gwpy
+lxml

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ requires = [
     'glue',
     'dqsegdb',
     'gwpy',
+    'lxml',
 ]
 tests_require = [
     'pytest'


### PR DESCRIPTION
This PR introduces two improvements to the significance drop plot

- added a kwarg for `plot.significance_drop` that displays just the channel system names (e.g. 'PSL') on the x-axis, rather than each channel name
- added SVG rendering with hover tooltips show the channel name

Each of the above should make the plots much easier to read. Compare [original](https://ldas-jobs.ligo-la.caltech.edu/~jrsmith/hveto/O1/Dec20Matlab/L1-omicron_BOTH-1134604817-86400-DARM/L1-HVETO_SIG_DROP_ROUND_1-1134604817-86400.png) versus [current](https://ldas-jobs.ligo-la.caltech.edu/~duncan.macleod/hveto/testing/benchmark/1134604817-1134691217/plots/L1-HVETO_SIG_DROP_ROUND_1-1134604817-86400.png) versus [new](https://ldas-jobs.ligo-la.caltech.edu/~duncan.macleod/hveto/testing/drop-plot/1134604817-1134691217/plots/L1-HVETO_SIG_DROP_ROUND_1-1134604817-86400.svg)