### PR TITLE
Set default significance to 0

### DIFF
--- a/hveto/core.py
+++ b/hveto/core.py
@@ -159,7 +159,7 @@ def find_max_significance(primary, auxiliary, channel, snrs, windows, livetime):
     rec.sort(order='time')
     coincs = find_all_coincidences(rec, channel, snrs, windows)
     winner = HvetoWinner(name='unknown', significance=-1)
-    sigs = dict((c, -1) for c in auxiliary)
+    sigs = dict((c, 0) for c in auxiliary)
     for p, cdict in coincs.items():
         dt, snr = p
         for chan in cdict:

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -230,7 +230,7 @@ def significance_drop(outfile, old, new, show_channel_names=None, **kwargs):
                 marker='o', markersize=10, label=c, zorder=old[c])
 
     ax.set_xlim(-1, len(channels))
-    ax.set_ybound(lower=-1)
+    ax.set_ybound(lower=0)
 
     # set xticks to show channel names
     if show_channel_names:


### PR DESCRIPTION
Previously the default was -1, probably to make sure that a significance of 0 was properly recorded, but the new coinc method doesn't record channels that have no coincs, so.... we need a default of 0.

This only affects the drop plot.