### PR TITLE
Optimised core.veto method

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -359,11 +359,11 @@ while True:
     write_ascii_segments(segfile, round.segments)
 
     # calculate significances for this round
-    def _find_max_significance(channels):
-        aux = dict((c, auxiliary[c]) for c in channels)
-        return core.find_max_significance(primary, aux, pchannel,
-                                          snrs, windows, round.livetime)
     if args.nproc > 1:  # multiprocessing
+        def _find_max_significance(channels):
+            aux = dict((c, auxiliary[c]) for c in channels)
+            return core.find_max_significance(primary, aux, pchannel,
+                                              snrs, windows, round.livetime)
         # separate channel list into chunks and process each chunk
         pool = multiprocessing.Pool(
             processes=min(args.nproc, len(auxiliary.keys())))

--- a/bin/hveto
+++ b/bin/hveto
@@ -49,7 +49,7 @@ from glue.lal import Cache
 from gwpy.time import to_gps
 from gwpy.segments import (DataQualityFlag, DataQualityDict)
 
-from hveto import (__version__, log, config, core, plot, html)
+from hveto import (__version__, log, config, core, plot, html, utils)
 from hveto.segments import write_ascii as write_ascii_segments
 from hveto.triggers import (get_triggers, find_auxiliary_channels,
                             write_ascii as write_ascii_triggers)
@@ -365,10 +365,9 @@ while True:
                                           snrs, windows, round.livetime)
     if args.nproc > 1:  # multiprocessing
         # separate channel list into chunks and process each chunk
-        allchans = auxiliary.keys()
-        pool = multiprocessing.Pool(processes=min(args.nproc, len(allchans)))
-        n = int(ceil(len(allchans) / args.nproc))
-        chunks = [allchans[i:i+n] for i in range(0, len(allchans), n)]
+        pool = multiprocessing.Pool(
+            processes=min(args.nproc, len(auxiliary.keys())))
+        chunks = utils.channel_groups(auxiliary.keys(), args.nproc)
         results = pool.map(_find_max_significance, chunks)
         pool.close()
         winners, sigsets = zip(*results)
@@ -443,8 +442,21 @@ while True:
         round.cum_deadtime = round.deadtime
 
     # apply vetoes to auxiliary
-    for channel in auxiliary:
-        auxiliary[channel], v = core.veto(auxiliary[channel], round.vetoes)
+    if args.nproc > 1:  # multiprocess
+        def _veto(channels):
+            return core.veto_all(dict((c, auxiliary[c]) for c in channels),
+                                 round.vetoes)
+        # separate channel list into chunks and process each chunk
+        pool = multiprocessing.Pool(
+            processes=min(args.nproc, len(auxiliary.keys())))
+        chunks = utils.channel_groups(auxiliary.keys(), args.nproc)
+        results = pool.map(_veto, chunks)
+        pool.close()
+        auxiliary = results[0]
+        for subdict in results[1:]:
+            auxiliary.update(subdict)
+    else:  # single process
+        auxiliary = core.veto_all(auxiliary, round.vetoes)
     logger.debug("Applied vetoes to auxiliary channels")
 
     # log results

--- a/hveto/core.py
+++ b/hveto/core.py
@@ -289,19 +289,72 @@ def find_coincidences(a, b, dt=1):
 
 def veto(table, segmentlist):
     """Remove events from a table based on a segmentlist
+
+    A time ``t`` will be vetoed if ``start <= t <= end`` for any veto
+    segment in the list.
+
+    Parameters
+    ----------
+    table : `numpy.recarray`
+        the table of event triggers to veto
+    segmentlist : `~glue.segments.segmentlist`
+        the list of veto segments to use
+
+    Returns
+    -------
+    keep : `numpy.recarray`
+        the reduced table of events that were not coincident with any
+        segments
     """
+    table.sort(order='time')
     times = table['time']
     segmentlist = type(segmentlist)(segmentlist).coalesce()
-    a = segmentlist[0][0]
-    b = segmentlist[-1][1]
     keep = numpy.ones(times.shape[0], dtype=bool)
-    for i, t in enumerate(times):
+    j = 0
+    a, b = segmentlist[j]
+    i = 0
+    while i < times.size:
+        t = times[i]
+        # if before start, move to next trigger now
         if t < a:
+            i += 1
             continue
+        # if after end, find the next segment and check this trigger again
         if t > b:
-            break
-        for seg in segmentlist:
-            if seg[0] <= t <= seg[1]:
-                keep[i] = False
+            j += 1
+            try:
+                a, b = segmentlist[j]
+                continue
+            except IndexError:
                 break
+        # otherwise it must be in this segment, record and move to next
+        keep[i] = False
+        i += 1
     return table[keep], table[~keep]
+
+
+def veto_all(auxiliary, segmentlist):
+    """Remove events from all auxiliary channel tables based on a segmentlist
+
+    Parameters
+    ----------
+    auxiliary : `dict` of `numpy.recarray`
+        a `dict` of event arrays to veto
+    segmentlist : `~glue.segments.segmentlist`
+        the list of veto segments to use
+
+    Returns
+    -------
+    survivors : `dict` of `numpy.recarray`
+        a dict of the reduced arrays of events for each input channel
+
+    See Also
+    --------
+    core.veto
+        for details on the veto algorithm itself
+    """
+    channels = auxiliary.keys()
+    rec = stack_arrays(auxiliary.values(), usemask=False,
+                       asrecarray=True, autoconvert=True)
+    keep, _ = veto(rec, segmentlist)
+    return dict((c, keep[keep['channel'] == c]) for c in channels)

--- a/hveto/core.py
+++ b/hveto/core.py
@@ -87,6 +87,7 @@ def find_all_coincidences(triggers, channel, snrs, windows):
     window : `list` of `float`
         the time windows to use
     """
+    triggers.sort(order='time')
     windows = sorted(windows, reverse=True)
     snrs = sorted(snrs)
     coincs = dict((p, {}) for p in itertools.product(windows, snrs))
@@ -156,7 +157,6 @@ def find_max_significance(primary, auxiliary, channel, snrs, windows, livetime):
     """
     rec = stack_arrays([primary] + auxiliary.values(), usemask=False,
                        asrecarray=True, autoconvert=True)
-    rec.sort(order='time')
     coincs = find_all_coincidences(rec, channel, snrs, windows)
     winner = HvetoWinner(name='unknown', significance=-1)
     sigs = dict((c, 0) for c in auxiliary)

--- a/hveto/core.py
+++ b/hveto/core.py
@@ -253,7 +253,7 @@ def significance(n, mu):
         sig = -n * log10(mu) + mu * LOG_EXP_1 + gammaln(n+1) / LOG_10
     else:
         sig = -log10(g)
-    return sig
+    return float(sig)
 
 
 def find_coincidences(a, b, dt=1):

--- a/hveto/tests/test_utils.py
+++ b/hveto/tests/test_utils.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Joshua Smith (2016-)
+#
+# This file is part of the hveto python package.
+#
+# hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hveto.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `hveto.utils`
+"""
+
+from hveto import utils
+
+from common import unittest
+
+
+class UtilsTestCase(unittest.TestCase):
+    def test_channel_groups(self):
+        self.assertListEqual(list(utils.channel_groups([1, 2, 3, 4, 5], 1)),
+                             [[1, 2, 3, 4, 5]])
+        self.assertListEqual(list(utils.channel_groups([1, 2, 3, 4, 5], 2)),
+                             [[1, 2, 3], [4, 5]])
+        self.assertListEqual(list(utils.channel_groups([1, 2, 3, 4, 5], 10)),
+                             [[1], [2], [3], [4], [5]])

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -132,10 +132,6 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
         recarray = recfunctions.rec_append_fields(recarray, names, data)
         recarray = recfunctions.rec_drop_fields(recarray, dropfields)
 
-    # sort by time
-    if 'time' in recarray.dtype.fields:
-        recarray.sort(order='time')
-
     # filter
     if snr is not None:
         recarray = recarray[recarray['snr'] >= snr]

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Joshua Smith (2016-)
+#
+# This file is part of the hveto python package.
+#
+# hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hveto.  If not, see <http://www.gnu.org/licenses/>.
+
+"""General utilities for hveto
+"""
+
+from math import ceil
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def channel_groups(channellist, ngroups):
+    """Separate a list of channels into a number of equally-sized groups
+
+    Parameters
+    ----------
+    channellist : `list`
+        large list to separate into chunks
+    ngroups : `int`
+        number of output groups
+
+    Returns
+    -------
+    iterator : iterator `list` of `list`
+        a generator sequence yielding a sub-list on each iteration
+    """
+    n = int(ceil(len(channellist) / ngroups))
+    for i in range(0, len(channellist), n):
+        yield channellist[i:i+n]

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -19,6 +19,8 @@
 """General utilities for hveto
 """
 
+from __future__ import division
+
 from math import ceil
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'


### PR DESCRIPTION
This PR introduces optimisations for the `hveto.core.veto` method used to remove triggers that overlap any veto segments. The method itself was modified to loop over the segmentlist only once, and I added the `hveto.core.veto_all` method to optimise applying the same set of veto segments to multiple channel sets at the same time.

The benchmark result is unchanged, this is just an under-the-hood change.