### PR TITLE
Adds hveto-trace feature

### DIFF
--- a/bin/hveto-trace
+++ b/bin/hveto-trace
@@ -45,14 +45,10 @@ pout = parser.add_argument_group('Output options')
 args = parser.parse_args()
 
 logger = log.Logger('hveto-trace', level=args.loglevel)
-trigger_time = args.trigger_time
+trigger_time = float(args.trigger_time)
 directory = args.directory
 logger.debug('Running in verbose mode')
-logger.debug('Directory to search is %s' % directory)
-if float(trigger_time) != round(float(trigger_time)):
-    logger.warning("""Be careful using floats. If the input time lies
-between vetoed segment start and end times, it will not be calculated as vetoed.""")
-
+logger.debug('Search directory: %s' % directory)
 if directory[-1] != '/':
     directory += '/'
 
@@ -64,47 +60,25 @@ except IOError:
     
 round_list = segment_stats[u'rounds']
 veto_seg_file_list = []
-vetoed = False
-for ind_round in round_list:
-    round_veto_seg_file = filter(
-        lambda f_name: '.txt' in f_name,
-        ind_round[u'files'][u'VETO_SEGS']
-    )[0]
-    veto_seg_file_list.append(round_veto_seg_file)
+get_segments = lambda line: [float(line.split('\t')[1]), float(line.split('\t')[2])]
+for i, cround in enumerate(segment_stats['rounds']):
+    seg_files = filter(
+        lambda f_name: '.txt' in f_name, cround[u'files'][u'VETO_SEGS'])
+    for f in seg_files:
+        lines = map(
+            lambda line: line.split('\t'),
+            open(os.path.join(directory, f)).read().split('\n'))[0:-1]
+        segment_list = map(
+            lambda line: [float(line[1]), float(line[2])],
+            lines)
+        for segment in segment_list:
+            if segment[0] <= trigger_time <= segment[1]:
+                logger.info('Signal was vetoed in round %d by segment %s'
+                    % ((i + 1), segment))
+                logger.debug('Winner: %s' % cround['name'])
+                logger.debug('Significance: %s' % cround['significance'])
+                logger.debug('SNR: %s' % cround['snr'])
+                logger.debug('Window: %s' % cround['window'])
+                sys.exit(0)
 
-x = 0
-while x < len(veto_seg_file_list):
-    veto_seg_file = veto_seg_file_list[x]
-    lines = open('%s%s' % (directory, veto_seg_file)).readlines()
-    j = 0
-    while j < len(lines):
-        line = lines[j]
-        rows = line.split('\t')
-        if trigger_time in line:
-            vetoed = True
-            l_bound = float(rows[1])
-            u_bound = float(rows[2])
-            seg_duration = float(rows[3])
-            veto_channel = round_list[x]['name']
-            round_significance = round_list[x]['significance']
-            round_snr = round_list[x]['snr']
-            break
-        j += 1
-    if vetoed:
-        break
-
-    x += 1
-
-if vetoed:
-    logger.info('Signal was vetoed in round %s on line %s of %s' % (
-        x + 1, j, veto_seg_file_list[x]))
-    logger.info('This round\'s winner was: %s' % veto_channel)
-    logger.debug('This was during segment %s - %s with time window %s seconds' % (
-                l_bound, u_bound, seg_duration))
-    logger.debug('The significance of this round was %s with SNR %s' % (
-                round_significance, round_snr))
-    logger.debug('See %sindex.html' % directory)
-
-else:
-    logger.info('Signal was not vetoed.')
-    
+logger.info('Signal was not vetoed.')    

--- a/bin/hveto-trace
+++ b/bin/hveto-trace
@@ -40,13 +40,13 @@ parser.add_argument('-v', '--verbose', help='Print more information',
 
 pout = parser.add_argument_group('Output options')
 
+directory = args.directory
 args = parser.parse_args()
 logger = log.Logger('hveto-trace', level=args.loglevel)
 logger.debug('Running in verbose mode')
 logger.debug('Search directory: %s' % directory)
 
 trigger_time = float(args.trigger_time)
-directory = args.directory
 if directory[-1] != '/':
     directory += '/'
 

--- a/bin/hveto-trace
+++ b/bin/hveto-trace
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) Joshua Smith (2016-)
+#
+# This file is part of the hveto python package.
+#
+# hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hveto.  If not, see <http://www.gnu.org/licenses/>.
+# """Check if a trigger was vetoed by a specified hveto run.
+# """
+
+
+import sys, json, argparse, os, logging
+from hveto import log
+
+# -- parse command line -------------------------------------------------------
+
+
+def abs_path(p):
+    return os.path.abspath(os.path.expanduser(p))
+
+parser = argparse.ArgumentParser(description=__doc__)
+
+parser.add_argument('-t', '--trigger-time', required=True,
+                    help='The time of the trigger in GPS time')
+parser.add_argument('-d', '--directory', default='.', type=abs_path,
+                    help='path to hveto-generated folder containing '
+                    'a summary-stats.json file')
+parser.add_argument('-v', '--verbose', help='Print more information',
+                    action='store_const', dest='loglevel', const=logging.DEBUG,
+                    default=logging.INFO)
+
+pout = parser.add_argument_group('Output options')
+
+args = parser.parse_args()
+
+logger = log.Logger('hveto-trace', level=args.loglevel)
+trigger_time = args.trigger_time
+directory = args.directory
+logger.debug('Running in verbose mode')
+logger.debug('Directory to search is %s' % directory)
+if float(trigger_time) != round(float(trigger_time)):
+    logger.warning("""Be careful using floats. If the input time lies
+between vetoed segment start and end times, it will not be calculated as vetoed.""")
+
+if directory[-1] != '/':
+    directory += '/'
+
+try:
+    segment_stats = json.load(open('%ssummary-stats.json' % directory))
+except IOError:
+    logger.error("'summary-stats.json' was not found in the input directory")
+    sys.exit(0)
+    
+round_list = segment_stats[u'rounds']
+veto_seg_file_list = []
+vetoed = False
+for ind_round in round_list:
+    round_veto_seg_file = filter(
+        lambda f_name: '.txt' in f_name,
+        ind_round[u'files'][u'VETO_SEGS']
+    )[0]
+    veto_seg_file_list.append(round_veto_seg_file)
+
+x = 0
+while x < len(veto_seg_file_list):
+    veto_seg_file = veto_seg_file_list[x]
+    lines = open('%s%s' % (directory, veto_seg_file)).readlines()
+    j = 0
+    while j < len(lines):
+        line = lines[j]
+        rows = line.split('\t')
+        if trigger_time in line:
+            vetoed = True
+            l_bound = float(rows[1])
+            u_bound = float(rows[2])
+            seg_duration = float(rows[3])
+            veto_channel = round_list[x]['name']
+            round_significance = round_list[x]['significance']
+            round_snr = round_list[x]['snr']
+            break
+        j += 1
+    if vetoed:
+        break
+
+    x += 1
+
+if vetoed:
+    logger.info('Signal was vetoed in round %s on line %s of %s' % (
+        x + 1, j, veto_seg_file_list[x]))
+    logger.info('This round\'s winner was: %s' % veto_channel)
+    logger.debug('This was during segment %s - %s with time window %s seconds' % (
+                l_bound, u_bound, seg_duration))
+    logger.debug('The significance of this round was %s with SNR %s' % (
+                round_significance, round_snr))
+    logger.debug('See %sindex.html' % directory)
+
+else:
+    logger.info('Signal was not vetoed.')
+    

--- a/bin/hveto-trace
+++ b/bin/hveto-trace
@@ -19,12 +19,10 @@
 # """Check if a trigger was vetoed by a specified hveto run.
 # """
 
-
 import sys, json, argparse, os, logging
 from hveto import log
 
 # -- parse command line -------------------------------------------------------
-
 
 def abs_path(p):
     return os.path.abspath(os.path.expanduser(p))
@@ -43,12 +41,12 @@ parser.add_argument('-v', '--verbose', help='Print more information',
 pout = parser.add_argument_group('Output options')
 
 args = parser.parse_args()
-
 logger = log.Logger('hveto-trace', level=args.loglevel)
-trigger_time = float(args.trigger_time)
-directory = args.directory
 logger.debug('Running in verbose mode')
 logger.debug('Search directory: %s' % directory)
+
+trigger_time = float(args.trigger_time)
+directory = args.directory
 if directory[-1] != '/':
     directory += '/'
 
@@ -57,10 +55,9 @@ try:
 except IOError:
     logger.error("'summary-stats.json' was not found in the input directory")
     sys.exit(0)
-    
-round_list = segment_stats[u'rounds']
-veto_seg_file_list = []
-get_segments = lambda line: [float(line.split('\t')[1]), float(line.split('\t')[2])]
+
+format_segment = lambda index: float(line.split('\t')[index])
+get_segments = lambda line: [format_segment(1),format_segment(2)]
 for i, cround in enumerate(segment_stats['rounds']):
     seg_files = filter(
         lambda f_name: '.txt' in f_name, cround[u'files'][u'VETO_SEGS'])

--- a/bin/hveto-trace
+++ b/bin/hveto-trace
@@ -21,6 +21,7 @@
 
 import sys, json, argparse, os, logging
 from hveto import log
+from gwpy.segments import SegmentList
 
 # -- parse command line -------------------------------------------------------
 
@@ -62,13 +63,8 @@ for i, cround in enumerate(segment_stats['rounds']):
     seg_files = filter(
         lambda f_name: '.txt' in f_name, cround[u'files'][u'VETO_SEGS'])
     for f in seg_files:
-        lines = map(
-            lambda line: line.split('\t'),
-            open(os.path.join(directory, f)).read().split('\n'))[0:-1]
-        segment_list = map(
-            lambda line: [float(line[1]), float(line[2])],
-            lines)
-        for segment in segment_list:
+        segments = SegmentList.read(os.path.join(directory, f))
+        for segment in segments:
             if segment[0] <= trigger_time <= segment[1]:
                 logger.info('Signal was vetoed in round %d by segment %s'
                     % ((i + 1), segment))

--- a/bin/hveto-trace
+++ b/bin/hveto-trace
@@ -32,7 +32,7 @@ parser = argparse.ArgumentParser(description=__doc__)
 
 parser.add_argument('-t', '--trigger-time', required=True,
                     help='The time of the trigger in GPS time')
-parser.add_argument('-d', '--directory', default='.', type=abs_path,
+parser.add_argument('-d', '--directory', required=True, type=abs_path,
                     help='path to hveto-generated folder containing '
                     'a summary-stats.json file')
 parser.add_argument('-v', '--verbose', help='Print more information',

--- a/bin/hveto-trace
+++ b/bin/hveto-trace
@@ -40,8 +40,8 @@ parser.add_argument('-v', '--verbose', help='Print more information',
 
 pout = parser.add_argument_group('Output options')
 
-directory = args.directory
 args = parser.parse_args()
+directory = args.directory
 logger = log.Logger('hveto-trace', level=args.loglevel)
 logger.debug('Running in verbose mode')
 logger.debug('Search directory: %s' % directory)


### PR DESCRIPTION
Known problem:
The current version checks if the input trigger is contained within a veto segment file using something like "if trigger_time in line". This means that if the inputted trigger lies between the lower & upper bounds of a veto segment, the program may not work properly. Some examples:

Veto segment: 1453212**1**.124120 - 1453212**2**.124120
Input trigger: 14521212**1.3**24120
This input lies inside of the segment but hveto-trace will not return "Trigger was vetoed."

The reason this is not fixed yet is shown in the following example:
**Veto segment**: 1135136350.**1**2450 - 113513650.**9**2450
**Input trigger**: 113513635**0**
We want this to return that the trigger was vetoed but simply checking if the input is between the veto segments would return that the trigger was not vetoed. Checking to see if the input trigger is contained within a string version of the veto segment will work though, which is the way the script works in its current form.

Thinking of a workaround.