### PR TITLE
Install astropy 1.1 for py26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
 
 before_install:
   - pip install -q --upgrade pip
+  # need to install astropy 1.1 specifically for py26
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
   - pip install ${PRE} -r requirements.txt
 
 install:


### PR DESCRIPTION
Astropy has removed support for python 2.6 as of astropy 1.2, so we need to force install v1.1 when using py2.6