### PR TITLE
New hveto-cache-events utility

### DIFF
--- a/bin/hveto-cache-events
+++ b/bin/hveto-cache-events
@@ -36,18 +36,21 @@ except ImportError:  # python 2.x
     import ConfigParser as configparser
 
 from glue.lal import (Cache, CacheEntry)
-from glue.ligolw.ligolw import (Document, LIGO_LW)
-from glue.ligolw.utils import write_filename as write_ligolw
+from glue.ligolw.ligolw import (Document, LIGO_LW, LIGOLWContentHandler)
+from glue.ligolw.utils import (write_filename as write_ligolw,
+                               load_filename as load_ligolw)
 from glue.ligolw.utils.process import (register_to_xmldoc as
                                        append_process_table)
 
-from gwpy.table.lsctables import (SnglBurstTable, SnglInspiralTable)
+from gwpy.table.lsctables import (SnglBurstTable, SnglInspiralTable,
+                                  New as new_table)
 from gwpy.time import to_gps
 from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 
 from hveto import (__version__, log, config)
-from hveto.triggers import (get_triggers, find_auxiliary_channels)
+from hveto.triggers import (get_triggers, find_auxiliary_channels,
+                            find_trigger_files)
 
 IFO = os.getenv('IFO')
 
@@ -90,6 +93,9 @@ parser.add_argument('-S', '--analysis-segments', action='append', default=[],
                     help='path to LIGO_LW XML file containing segments for '
                          'the analysis flag (name in segment_definer table '
                          'must match analysis-flag in config file)')
+parser.add_argument('--append', action='store_true', default=False,
+                    help='append to existing cached event files, otherwise, '
+                         'start from scratch (default)')
 
 pout = parser.add_argument_group('Output options')
 pout.add_argument('-o', '--output-directory', default=os.curdir,
@@ -151,37 +157,90 @@ logger.info("Retrieved %d segments for %s with %ss (%.2f%%) livetime"
 snrs = cp.getfloats('hveto', 'snr-thresholds')
 minsnr = min(snrs)
 
-# -- define writer ------------------------------------------------------------
+# -- utility methods ----------------------------------------------------------
+
+contenthandler = LIGOLWContentHandler
 
 
-def write_events(channel, tab):
-    """Write events to file with a given filename
-    """
-    # if empty, skip
-    if tab.shape[0] == 0:
-        return
-    # create filename
+def create_filename(channel):
     ifo, name = channel.split(':', 1)
     name = name.replace('-', '_')
-    filename = '%s-%s-%d-%d.xml.gz' % (ifo, name, start, duration)
+    return os.path.join(trigdir,
+                        '%s-%s-%d-%d.xml.gz' % (ifo, name, start, duration))
+
+
+def read_and_cache_events(channel, etg, cache=None, trigfindkwargs={},
+                          **getkwargs):
+    cfile = create_filename(channel)
+    # read existing cached triggers and work out new segments to query
+    if args.append and os.path.isfile(cfile):
+        previous = DataQualityFlag.read(cfile, format='ligolw').coalesce()
+        new = analysis - previous
+    else:
+        new = analysis.copy()
+    # get cache of files
+    if cache is None:
+        cache = find_trigger_files(channel, etg, new.active, **trigfindkwargs)
+    else:
+        cache = cache.sieve(segments=new.active)
+    # restrict 'active' segments to when we have data
+    try:
+        new.active &= cache.to_segmentlistdict().values()[0]
+    except IndexError:
+        new.active = type(new.active)()
+    # find new triggers
+    try:
+        trigs = get_triggers(channel, auxetg, new.active, cache=cache,
+                             raw=True, **getkwargs)
+    # catch error and continue
+    except ValueError as e:
+        warnings.warn('%s: %s' % (type(e).__name__, str(e)))
+    else:
+        a = write_events(channel, trigs, new)
+        try:
+            return CacheEntry.from_T050017(a), trigs.size
+        except TypeError:  # None
+            return
+
+
+def write_events(channel, tab, segments):
+    """Write events to file with a given filename
+    """
+    # get filename
+    filename = create_filename(channel)
+    # if empty, skip
+    if tab.shape[0] == 0 and args.append and os.path.isfile(filename):
+        return filename
+    elif tab.shape[0] == 0:
+        return
     # get table class and convert back to LIGO_LW table object
     if 'peak_time' in tab.dtype.fields:
         Table = SnglBurstTable
     else:
         Table = SnglInspiralTable
     llwtable = Table.from_recarray(tab)
-    # create document
-    xmldoc = Document()
-    xmldoc.appendChild(LIGO_LW())
+    # read existing document
+    if args.append and os.path.isfile(filename):
+        xmldoc = load_ligolw(filename, gz=True,
+                             contenthandler=LIGOLWContentHandler)
+    # or, create document
+    else:
+        xmldoc = Document()
+        xmldoc.appendChild(LIGO_LW())
     # append process table
     append_process_table(xmldoc, os.path.basename(__file__), {})
     # append segment tables
-    analysis.write(xmldoc, format='ligolw')
+    segments.write(xmldoc, format='ligolw')
     # append event table
-    xmldoc.childNodes[-1].appendChild(llwtable)
+    try:
+        etable = Table.get_table(xmldoc)
+    except ValueError:
+        etable = new_table(Table, columns=tab.dtype.fields)
+        xmldoc.childNodes[-1].appendChild(etable)
+    etable.extend(llwtable)
     # write file to disk
     write_ligolw(xmldoc, filename, gz=True)
-    return os.path.join(trigdir, filename)
+    return filename
 
 
 # -- load channels ------------------------------------------------------------
@@ -240,31 +299,40 @@ logger.info("Identified %d auxiliary channels to process" % naux)
 
 # -- load primary triggers ----------------------------------------------------
 
+logger.info("Reading events for primary channel...")
+
 # read primary cache
 if args.primary_cache:
     pcache = Cache.fromfilenames(args.primary_cache)
 else:
     pcache = None
 
-# load primary triggers
+# get primary params
 petg = cp.get('primary', 'trigger-generator')
 psnr = cp.getfloat('primary', 'snr-threshold')
 pfreq = cp.getfloats('primary', 'frequency-range')
 ptrigfind = dict((key.split('-', 1)[1], val) for (key, val) in
                  cp.items('primary') if key.startswith('trigfind-'))
-primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
-                       cache=pcache, raw=True, **ptrigfind)
-pfile = write_events(pchannel, primary)
 
-if len(primary):
-    logger.info("Cached %d events for %s" % (len(primary), pchannel))
+# load primary triggers
+out = read_and_cache_events(pchannel, petg, snr=psnr, frange=pfreq,
+                            cache=pcache, trigfindkwargs=ptrigfind)
+try:
+    e, n = out
+except TypeError:
+    e = None
+    n = 0
+if n:
+    logger.info("Cached %d new events for %s" % (n, pchannel))
+elif args.append and os.path.isfile(e.path):
+    logger.info("Cached 0 new events for %s" % pchannel)
 else:
     message = "No events found for %r in %d seconds of livetime" % (
        pchannel, livetime)
     logger.critical(message)
 
 # write primary to local cache
-pcache = Cache([CacheEntry.from_T050017(pfile)])
+pcache = Cache([e])
 with open('%s-HVETO_PRIMARY_CACHE-%d-%d.lcf'
           % (ifo, start, duration), 'w') as f:
     pcache.tofile(f)
@@ -283,36 +351,25 @@ def read_and_write_aux_triggers(channel):
         ifo, name = channel.split(':')
         desc = name.replace('-', '_')
         auxcache = acache.sieve(ifos=ifo, description='%s*' % desc)
-    # get triggers
+    out = read_and_cache_events(channel, auxetg, cache=auxcache, snr=minsnr,
+                                frange=auxfreq)
     try:
-        trigs = get_triggers(channel, auxetg, analysis.active, snr=minsnr,
-                             frange=auxfreq, cache=auxcache, raw=True)
-    # catch error and continue
-    except ValueError as e:
-        warnings.warn('%s: %s' % (type(e).__name__, str(e)))
-        out = None
-    else:
-        a = write_events(channel, trigs)
-        try:
-            out = CacheEntry.from_T050017(a)
-        except TypeError:  # none
-            out = None
-
+        e, n = out
+    except TypeError:
+        e = None
+        n = 0
     # log result of load
     with counter.get_lock():
         counter.value += 1
         tag = '[%d/%d]' % (counter.value, naux)
-        if out is None:  # something went wrong
+        if e is None:  # something went wrong
             logger.critical("    %s Failed to read events for %s"
                             % (tag, channel))
-        elif trigs.size:  # no triggers
-            logger.debug("    %s Cached %d events for %s"
-                         % (tag, trigs.size, channel))
-        else:  # everything is fine
-            logger.warning("    %s No events found for %s"
-                           % (tag, channel))
+        else:  # either read events or nothing new
+            logger.debug("    %s Cached %d new events for %s"
+                         % (tag, n, channel))
+    return e
 
-    return out
 
 # map with multiprocessing
 if args.nproc > 1:

--- a/bin/hveto-cache-events
+++ b/bin/hveto-cache-events
@@ -1,0 +1,340 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) Joshua Smith (2016)
+#
+# This file is part of the hveto python package.
+#
+# hveto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# hveto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with hveto.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Create a (temporary) cache of event triggers for analysis by `hveto` later
+
+This method will apply the minimal SNR thresholds and any frequency cuts
+as given in the configuration files
+"""
+
+from __future__ import (division, print_function)
+
+import argparse
+import os
+import warnings
+import multiprocessing
+import json
+import datetime
+
+try:
+    import configparser
+except ImportError:  # python 2.x
+    import ConfigParser as configparser
+
+from glue.lal import (Cache, CacheEntry)
+from glue.ligolw.ligolw import (Document, LIGO_LW)
+from glue.ligolw.utils import write_filename as write_ligolw
+from glue.ligolw.utils.process import (register_to_xmldoc as
+                                       append_process_table)
+
+from gwpy.table.lsctables import (SnglBurstTable, SnglInspiralTable)
+from gwpy.time import to_gps
+from gwpy.segments import (Segment, SegmentList,
+                           DataQualityFlag, DataQualityDict)
+
+from hveto import (__version__, log, config)
+from hveto.triggers import (get_triggers, find_auxiliary_channels)
+
+IFO = os.getenv('IFO')
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Joshua Smith <joshua.smith@ligo.org>'
+
+logger = log.Logger('hveto-cache-events')
+
+
+# -- parse command line -------------------------------------------------------
+
+def abs_path(p):
+    return os.path.abspath(os.path.expanduser(p))
+
+parser = argparse.ArgumentParser(description=__doc__)
+
+parser.add_argument('-V', '--version', action='version', version=__version__)
+parser.add_argument('gpsstart', type=to_gps, help='GPS start time of analysis')
+parser.add_argument('gpsend', type=to_gps, help='GPS end time of analysis')
+parser.add_argument('-f', '--config-file', action='append', default=[],
+                    type=abs_path,
+                    help='path to hveto configuration file, can be given '
+                         'multiple times (files read in order)')
+parser.add_argument('-i', '--ifo', default=IFO, required=IFO is None,
+                    help='prefix of IFO to process, default: %(default)s')
+parser.add_argument('-j', '--nproc', type=int, default=1,
+                    help='number of cores to use for multiprocessing, '
+                         'default: %(default)s')
+parser.add_argument('-p', '--primary-cache', action='append', default=[],
+                    type=abs_path,
+                    help='path for cache containing primary channel files')
+parser.add_argument('-a', '--auxiliary-cache', action='append', default=[],
+                    type=abs_path,
+                    help='path for cache containing auxiliary channel files, '
+                         'files contained must be T050017-compliant with the '
+                         'channel name as the leading name parts, e.g. '
+                         '\'L1-GDS_CALIB_STRAIN_<tag>-<start>-<duration>.'
+                         '<ext>\' for L1:GDS-CALIB_STRAIN triggers')
+parser.add_argument('-S', '--analysis-segments', action='append', default=[],
+                    type=abs_path,
+                    help='path to LIGO_LW XML file containing segments for '
+                         'the analysis flag (name in segment_definer table '
+                         'must match analysis-flag in config file)')
+
+pout = parser.add_argument_group('Output options')
+pout.add_argument('-o', '--output-directory', default=os.curdir,
+                  help='path of output directory, default: %(default)s')
+
+args = parser.parse_args()
+
+ifo = args.ifo
+start = args.gpsstart.seconds
+end = args.gpsend.seconds
+duration = end - start
+
+logger.info("-- Welcome to Hveto --")
+logger.info("GPS start time: %d" % start)
+logger.info("GPS end time: %d" % end)
+logger.info("Interferometer: %s" % ifo)
+
+# -- initialisation -----------------------------------------------------------
+
+# read configuration
+cp = config.HvetoConfigParser(ifo=args.ifo)
+cp.read(args.config_file)
+logger.info("Parsed configuration file(s)")
+
+# format output directory
+outdir = abs_path(args.output_directory)
+if not os.path.isdir(outdir):
+    os.makedirs(outdir)
+os.chdir(outdir)
+logger.info("Working directory: %s" % outdir)
+trigdir = 'triggers'
+if not os.path.isdir(trigdir):
+    os.makedirs(trigdir)
+
+os.chdir(trigdir)
+trigdir = os.getcwd()
+
+# get segments
+aflag = cp.get('segments', 'analysis-flag')
+url = cp.get('segments', 'url')
+padding = cp.getfloats('segments', 'padding')
+if args.analysis_segments:
+    segs_ = DataQualityDict.read(args.analysis_segments, gpstype=float)
+    analysis = segs_[aflag]
+    span = SegmentList([Segment(start, end)])
+    analysis.active &= span
+    analysis.known &= span
+    analysis.coalesce()
+    logger.debug("Segments read from disk")
+else:
+    analysis = DataQualityFlag.query(aflag, start, end, url=url)
+    logger.debug("Segments recovered from %s" % url)
+analysis.pad(*padding)
+livetime = int(abs(analysis.active))
+livetimepc = livetime / duration * 100.
+logger.info("Retrieved %d segments for %s with %ss (%.2f%%) livetime"
+            % (len(analysis.active), aflag, livetime, livetimepc))
+
+snrs = cp.getfloats('hveto', 'snr-thresholds')
+minsnr = min(snrs)
+
+# -- define writer ------------------------------------------------------------
+
+
+def write_events(channel, tab):
+    """Write events to file with a given filename
+    """
+    # if empty, skip
+    if tab.shape[0] == 0:
+        return
+    # create filename
+    ifo, name = channel.split(':', 1)
+    name = name.replace('-', '_')
+    filename = '%s-%s-%d-%d.xml.gz' % (ifo, name, start, duration)
+    # get table class and convert back to LIGO_LW table object
+    if 'peak_time' in tab.dtype.fields:
+        Table = SnglBurstTable
+    else:
+        Table = SnglInspiralTable
+    llwtable = Table.from_recarray(tab)
+    # create document
+    xmldoc = Document()
+    xmldoc.appendChild(LIGO_LW())
+    # append process table
+    append_process_table(xmldoc, os.path.basename(__file__), {})
+    # append segment tables
+    analysis.write(xmldoc, format='ligolw')
+    # append event table
+    xmldoc.childNodes[-1].appendChild(llwtable)
+    # write file to disk
+    write_ligolw(xmldoc, filename, gz=True)
+    return os.path.join(trigdir, filename)
+
+
+# -- load channels ------------------------------------------------------------
+
+# get primary channel name
+pchannel = cp.get('primary', 'channel')
+
+# read auxiliary cache
+if args.auxiliary_cache:
+    acache = Cache.fromfilenames(args.auxiliary_cache)
+else:
+    acache = None
+
+# load auxiliary channels
+auxetg = cp.get('auxiliary', 'trigger-generator')
+auxfreq = cp.getfloats('auxiliary', 'frequency-range')
+try:
+    auxchannels = cp.get('auxiliary', 'channels').strip('\n').split('\n')
+except config.configparser.NoOptionError:
+    auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo,
+                                          cache=acache)
+
+# load unsafe channels list
+_unsafe = cp.get('safety', 'unsafe-channels')
+if os.path.isfile(_unsafe):  # from file
+    unsafe = set()
+    with open(_unsafe, 'rb') as f:
+        for c in f.read().rstrip('\n').split('\n'):
+            if c.startswith('%(IFO)s'):
+                unsafe.add(c.replace('%(IFO)s', ifo))
+            elif not c.startswith('%s:' % ifo):
+                unsafe.add('%s:%s' % (ifo, c))
+            else:
+                unsafe.add(c)
+else:  # or from line-seprated list
+    unsafe = set(_unsafe.strip('\n').split('\n'))
+unsafe.add(pchannel)
+cp.set('safety', 'unsafe-channels', '\n'.join(sorted(unsafe)))
+logger.debug("Read list of %d unsafe channels" % len(unsafe))
+
+# remove duplicates
+auxchannels = sorted(set(auxchannels))
+logger.debug("Read list of %d auxiliary channels" % len(auxchannels))
+
+# remove unsafe channels
+nunsafe = 0
+for i in xrange(len(auxchannels) -1, -1, -1):
+    if auxchannels[i] in unsafe:
+        logger.warning("Auxiliary channel %r identified as unsafe and has "
+                       "been removed" % auxchannels[i])
+        auxchannels.pop(i)
+        nunsafe += 1
+logger.debug("%d auxiliary channels identified as unsafe" % nunsafe)
+naux = len(auxchannels)
+logger.info("Identified %d auxiliary channels to process" % naux)
+
+# -- load primary triggers ----------------------------------------------------
+
+# read primary cache
+if args.primary_cache:
+    pcache = Cache.fromfilenames(args.primary_cache)
+else:
+    pcache = None
+
+# load primary triggers
+petg = cp.get('primary', 'trigger-generator')
+psnr = cp.getfloat('primary', 'snr-threshold')
+pfreq = cp.getfloats('primary', 'frequency-range')
+ptrigfind = dict((key.split('-', 1)[1], val) for (key, val) in
+                 cp.items('primary') if key.startswith('trigfind-'))
+primary = get_triggers(pchannel, petg, analysis.active, snr=psnr, frange=pfreq,
+                       cache=pcache, raw=True, **ptrigfind)
+pfile = write_events(pchannel, primary)
+
+if len(primary):
+    logger.info("Cached %d events for %s" % (len(primary), pchannel))
+else:
+    message = "No events found for %r in %d seconds of livetime" % (
+       pchannel, livetime)
+    logger.critical(message)
+
+# write primary to local cache
+pcache = Cache([CacheEntry.from_T050017(pfile)])
+with open('%s-HVETO_PRIMARY_CACHE-%d-%d.lcf'
+          % (ifo, start, duration), 'w') as f:
+    pcache.tofile(f)
+pname = os.path.join(trigdir, f.name)
+logger.info('Primary cache written to %s' % pname)
+
+# -- load auxiliary triggers --------------------------------------------------
+
+logger.info("Reading triggers for aux channels...")
+counter = multiprocessing.Value('i', 0)
+
+def read_and_write_aux_triggers(channel):
+    if acache is None:
+        auxcache = None
+    else:
+        ifo, name = channel.split(':')
+        desc = name.replace('-', '_')
+        auxcache = acache.sieve(ifos=ifo, description='%s*' % desc)
+    # get triggers
+    try:
+        trigs = get_triggers(channel, auxetg, analysis.active, snr=minsnr,
+                             frange=auxfreq, cache=auxcache, raw=True)
+    # catch error and continue
+    except ValueError as e:
+        warnings.warn('%s: %s' % (type(e).__name__, str(e)))
+        out = None
+    else:
+        a = write_events(channel, trigs)
+        try:
+            out = CacheEntry.from_T050017(a)
+        except TypeError:  # none
+            out = None
+
+    # log result of load
+    with counter.get_lock():
+        counter.value += 1
+        tag = '[%d/%d]' % (counter.value, naux)
+        if out is None:  # something went wrong
+            logger.critical("    %s Failed to read events for %s"
+                            % (tag, channel))
+        elif trigs.size:  # no triggers
+            logger.debug("    %s Cached %d events for %s"
+                         % (tag, trigs.size, channel))
+        else:  # everything is fine
+            logger.warning("    %s No events found for %s"
+                           % (tag, channel))
+
+    return out
+
+# map with multiprocessing
+if args.nproc > 1:
+    pool = multiprocessing.Pool(processes=args.nproc)
+    results = pool.map(read_and_write_aux_triggers, auxchannels)
+    pool.close()
+# map without multiprocessing
+else:
+    results = map(read_and_write_aux_triggers, auxchannels)
+
+acache = Cache(x for x in results if x is not None)
+with open('%s-HVETO_AUXILIARY_CACHE-%d-%d.lcf'
+          % (ifo, start, duration), 'w') as f:
+    acache.tofile(f)
+aname = os.path.join(trigdir, f.name)
+logger.info('Auxiliary cache written to %s' % aname)
+
+# -- finish -------------------------------------------------------------------
+
+logger.info('Done, you can use these cache files in an hveto analysis by '
+            'passing the following arguments:\n --primary-cache %s '
+            '--auxiliary-cache %s' % (pname, aname))

--- a/bin/hveto-cache-events
+++ b/bin/hveto-cache-events
@@ -23,14 +23,12 @@ This method will apply the minimal SNR thresholds and any frequency cuts
 as given in the configuration files
 """
 
-from __future__ import (division, print_function)
+from __future__ import division
 
 import argparse
 import os
 import warnings
 import multiprocessing
-import json
-import datetime
 
 try:
     import configparser
@@ -54,7 +52,6 @@ from hveto.triggers import (get_triggers, find_auxiliary_channels)
 IFO = os.getenv('IFO')
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-__credits__ = 'Joshua Smith <joshua.smith@ligo.org>'
 
 logger = log.Logger('hveto-cache-events')
 


### PR DESCRIPTION
I have written up a new utility executable `hveto-cache-events`, which can be used to read primary and auxiliary triggers from their original locations and dump them to a local cache. This is, I think, analogous to the previous solution by @areeda to read omicron files into ascii to speed up processing.

There is an `--append` option that can be used to allow multiple calls for the same period over time, with new triggers being appended to the local files as they are discovered.

The usage is essentially identical to that of the `hveto` executable call, since the GPS times, and configuration files are all needed to work out what channels to find and what triggers to read, e.g.

```
hveto-cache-events 1135036817 1135123217 -i L1 -f /path/to/config.ini --apend
```

The output is to a `triggers/` sub-directory of the `--output-directory`, which can be the same as the main hveto output directory for the same period.