### PR TITLE
Need to build HTML <head> tag manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
 
 before_install:
   - pip install -q --upgrade pip
-  # need to install astropy 1.1 specifically for py26
-  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
+  # install specific packages for python2.6
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "scipy<0.18" "astropy<1.2"; fi
   - pip install ${PRE} -r requirements.txt
 
 install:

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -129,7 +129,7 @@ def write_static_files(static):
     return hvetocss, hvetojs
 
 
-def init_page(ifo, start, end, css=[], script=[], **kwargs):
+def init_page(ifo, start, end, css=[], script=[], base=os.path.curdir):
     """Initialise a new `markup.page`
 
     This method constructs an HTML page with the following structure
@@ -157,36 +157,42 @@ def init_page(ifo, start, end, css=[], script=[], **kwargs):
         the GPS start time of the analysis
     end : `int`
         the GPS end time of the analysis
-    **kwargs
-        other keyword arguments are passed to `markup.page.init`
+    css : `list`, optional
+        the list of stylesheets to link in the `<head>`
+    script : `list`, optional
+        the list of javascript files to link in the `<head>`
+    base : `str`, optional, default '.'
+        the path for the `<base>` tag to link in the `<head>`
 
     Returns
     -------
     page : `markup.page`
         the structured markup to open an HTML document
     """
-    base = kwargs.pop('base', os.path.curdir)
     # write CSS to static dir
-    staticdir = os.path.join(base, 'static')
+    staticdir = os.path.join(os.path.curdir, 'static')
     write_static_files(staticdir)
     # create page
     page = markup.page()
-    # add bootstrap CSS and JS if needed
+    page.header.append('<!DOCTYPE HTML>')
+    page.head(lang='en')
+    page.base(href=base)
+    # link stylesheets (appending bootstrap if needed)
     css = css[:]
     for cssf in CSS_FILES[::-1]:
         b = os.path.basename(cssf)
         if not any(f.endswith(b) for f in css):
             css.insert(0, cssf)
+    for f in css:
+        page.link(href=f, rel='stylesheet', type='text/css', media='all')
+    # link javascript
     script = script[:]
     for jsf in JS_FILES[::-1]:
         b = os.path.basename(jsf)
         if not any(f.endswith(b) for f in script):
             script.insert(0, jsf)
-    # create page and init
-    kwargs['css'] = css
-    kwargs['script'] = script
-    page.init(base=base, **kwargs)
-
+    for f in script:
+        page.script('', src=f, type='text/javascript')
     # write banner
     page.div(class_='container')
     page.div(class_='page-header', role='banner')

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -453,7 +453,7 @@ def write_footer(about=None, date=None):
     """
     page = markup.page()
     page.twotags.append('footer')
-    markup.element('footer', parent=page)(class_='footer')
+    markup.element('footer', case=page.case, parent=page)(class_='footer')
     page.div(class_='container')
     # write user/time for analysis
     if date is None:
@@ -468,7 +468,8 @@ def write_footer(about=None, date=None):
     # link to 'about'
     if about is not None:
         page.a('How was this page generated?', href=about)
-    markup.element('footer', parent=page).close()
+    page.div.close()  # container
+    markup.element('footer', case=page.case, parent=page).close()
     return page
 
 

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -175,8 +175,10 @@ def init_page(ifo, start, end, css=[], script=[], base=os.path.curdir):
     # create page
     page = markup.page()
     page.header.append('<!DOCTYPE HTML>')
-    page.head(lang='en')
+    page.html(lang='en')
+    page.head()
     page.base(href=base)
+    page._full = True
     # link stylesheets (appending bootstrap if needed)
     css = css[:]
     for cssf in CSS_FILES[::-1]:
@@ -193,6 +195,9 @@ def init_page(ifo, start, end, css=[], script=[], base=os.path.curdir):
             script.insert(0, jsf)
     for f in script:
         page.script('', src=f, type='text/javascript')
+    # finalize header
+    page.head.close()
+    page.body()
     # write banner
     page.div(class_='container')
     page.div(class_='page-header', role='banner')
@@ -235,8 +240,9 @@ def close_page(page, target, about=None, date=None):
     """
     page.div.close()  # container
     page.add(str(write_footer(about=about, date=date)))
-    page.body.close()
-    page.html.close()
+    if not page._full:
+        page.body.close()
+        page.html.close()
     with open(target, 'w') as f:
         f.write(page())
     return page

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -129,7 +129,8 @@ def write_static_files(static):
     return hvetocss, hvetojs
 
 
-def init_page(ifo, start, end, css=[], script=[], base=os.path.curdir):
+def init_page(ifo, start, end, css=[], script=[], base=os.path.curdir,
+              **kwargs):
     """Initialise a new `markup.page`
 
     This method constructs an HTML page with the following structure
@@ -195,6 +196,9 @@ def init_page(ifo, start, end, css=[], script=[], base=os.path.curdir):
             script.insert(0, jsf)
     for f in script:
         page.script('', src=f, type='text/javascript')
+    # add other attributes
+    for key in kwargs:
+        getattr(page, key)(kwargs[key])
     # finalize header
     page.head.close()
     page.body()

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -19,7 +19,7 @@
 """Tests for `hveto.html`
 """
 
-import os.path
+import os
 import tempfile
 import shutil
 import time
@@ -68,13 +68,19 @@ HTML_CLOSE = """</div>
 </body>
 </html>""" % HTML_FOOTER
 
-class HtmlTestCase(unittest.TestCase):
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
 
-    def tearDown(self):
-        if os.path.isdir(self.tempdir):
-            shutil.rmtree(self.tempdir)
+class HtmlTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        os.chdir(cls.tempdir)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.isdir(cls.tempdir):
+            shutil.rmtree(cls.tempdir)
+        del cls.tempdir
 
     def test_init_page(self):
         # test simple content

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -75,12 +75,15 @@ class HtmlTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tempdir = tempfile.mkdtemp()
+        cls._startdir = os.getcwd()
         os.chdir(cls.tempdir)
 
     @classmethod
     def tearDownClass(cls):
+        os.chdir(cls._startdir)
         if os.path.isdir(cls.tempdir):
             shutil.rmtree(cls.tempdir)
+        del cls._startdir
         del cls.tempdir
 
     def test_init_page(self):

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -34,9 +34,10 @@ from common import unittest
 VERSION = get_versions()['version']
 COMMIT = get_versions()['full-revisionid']
 
-HTML_INIT = """<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'>
+HTML_INIT = """<!DOCTYPE HTML>
 <html lang="en">
 <head>
+<base href="{base}" />
 <link media="all" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" type="text/css" rel="stylesheet" />
 <link media="all" href="//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" type="text/css" rel="stylesheet" />
 <link media="all" href="//fonts.googleapis.com/css?family=Lato:300,700" type="text/css" rel="stylesheet" />
@@ -45,7 +46,6 @@ HTML_INIT = """<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js" type="text/javascript"></script>
 <script src="{js}" type="text/javascript"></script>
-<base href="{base}" />
 </head>
 <body>
 <div class="container">
@@ -79,8 +79,8 @@ class HtmlTestCase(unittest.TestCase):
     def test_init_page(self):
         # test simple content
         out = html.init_page('L1', 0, 100, base=self.tempdir)
-        css = os.path.join(self.tempdir, 'static', 'hveto.css')
-        js = os.path.join(self.tempdir, 'static', 'hveto.js')
+        css = os.path.join(os.path.curdir, 'static', 'hveto.css')
+        js = os.path.join(os.path.curdir, 'static', 'hveto.js')
         self.assertEqual(str(out),
                          HTML_INIT.format(base=self.tempdir, css=css, js=js))
 

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -61,6 +61,7 @@ HTML_INIT = """<!DOCTYPE HTML>
 HTML_FOOTER = """<footer class="footer">
 <div class="container">
 <p>Page generated using <a href="https://github.com/hveto/hveto/tree/%s" target="_blank">Hveto version %s</a> by {user} at {date}</p>
+</div>
 </footer>""" % (COMMIT, VERSION)
 
 HTML_CLOSE = """</div>


### PR DESCRIPTION
This PR modifies the `html.ini_page` method to build the HTML `<head>` tag manually - markup.py 1.10 links the `<base>` tag after the stylesheets and javascript, which is bad, so we need manually override it for now.

I have contacted the markup maintainers to fix this, so we might be able to revert this after a 1.11 release.