### PR TITLE
Added option to generate omega scans of loudest vetoed glitches

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -31,6 +31,7 @@ import warnings
 import multiprocessing
 import json
 import datetime
+import subprocess
 import sys
 from socket import getfqdn
 from getpass import getuser
@@ -40,6 +41,8 @@ try:
     import configparser
 except ImportError:  # python 2.x
     import ConfigParser as configparser
+
+from numpy import unique
 
 from matplotlib import use
 use('agg')
@@ -97,6 +100,9 @@ parser.add_argument('-S', '--analysis-segments', action='append', default=[],
                     help='path to LIGO_LW XML file containing segments for '
                          'the analysis flag (name in segment_definer table '
                          'must match analysis-flag in config file)')
+parser.add_argument('-w', '--omega-scans', type=int, metavar='NSCAN',
+                    help='generate a workflow of omega scans for each round, '
+                         'requires the gwdetchar package')
 
 pout = parser.add_argument_group('Output options')
 pout.add_argument('-o', '--output-directory', default=os.curdir,
@@ -130,7 +136,8 @@ logger.info("Working directory: %s" % outdir)
 segdir = 'segments'
 plotdir = 'plots'
 trigdir = 'triggers'
-for d in [segdir, plotdir, trigdir]:
+omegadir = 'scans'
+for d in [segdir, plotdir, trigdir, omegadir]:
     if not os.path.isdir(d):
         os.makedirs(d)
 
@@ -518,6 +525,13 @@ cum. deadtime :   %s""" % (
                      % (round.n, tag.lower(), f))
         round.files[tag] = f
 
+    # record times for omega scans
+    if args.omega_scans:
+        vetoed.sort(order='snr')
+        round.scans = vetoed[-args.omega_scans:][::-1]
+        logger.debug("Identified %d events for omega scan\n%s"
+                     % (args.omega_scans, round.scans))
+
     # -- make some plots --
 
     pngname = os.path.join(plotdir, '%s-HVETO_%%s_ROUND_%d-%d-%d.png' %
@@ -735,7 +749,21 @@ with open('summary-stats.json', 'w') as f:
     json.dump(json_, f, sort_keys=True)
 logger.debug("Summary JSON written to %s" % f.name)
 
+# -- generate workflow for omega scans
+
+if args.omega_scans:
+    logger.info('Creating workflow for omega scans...')
+    omegatimes = list(map(str, sorted(unique(
+        [t['time'] for r in rounds for t in r.scans]))))
+    batch = ['wdq-batch'] + omegatimes + ['--output-dir', omegadir]
+    proc = subprocess.Popen(batch)
+    out, err = proc.communicate()
+    if proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, ' '.join(batch))
+    dagfile = os.path.join(omegadir, 'condor', 'wdq-batch.dag')
+
 # -- write HTML and finish
+
 index = html.write_hveto_page(ifo, start, end, rounds, plots,  **htmlv)
 logger.debug("HTML written to %s" % index)
 logger.debug("Analysis completed in %d seconds" % (time.time() - jobstart))

--- a/hveto/core.py
+++ b/hveto/core.py
@@ -52,6 +52,7 @@ class HvetoRound(object):
         'cum_deadtime',
         'plots',
         'files',
+        'scans',
     )
 
     def __init__(self, round, segments=None, vetoes=None, plots=[], files={}):
@@ -60,6 +61,7 @@ class HvetoRound(object):
         self.vetoes = vetoes
         self.plots = []
         self.files = {}
+        self.scans = None
 
     @property
     def livetime(self):

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -634,6 +634,18 @@ def write_round(round):
         link = ' '.join([html_link(
             f, '[%s]' % os.path.splitext(f)[1].strip('.')) for f in files])
         page.add(bold_param(desc, link))
+    # link omega scans if generated
+    if round.scans is not None:
+        page.p('<b>Omega scans:</b>')
+        for t in round.scans:
+            page.p()
+            page.a('%s [SNR %.1f]' % (t['time'], t['snr']),
+                href='./scans/%s/' % t['time'], **{
+                'class_': 'fancybox',
+                'rel': 'hveto-image',
+                'target': '_blank',
+            })
+            page.p.close()
     page.div.close()  # col
     # plots
     page.div(class_='col-md-9', id_='hveto-round-%d-plots' % round.n)

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ requires = [
     'dqsegdb',
     'gwpy',
     'lxml',
+    'gwdetchar',  # for omega scans only
 ]
 tests_require = [
     'pytest'


### PR DESCRIPTION
This PR fixes #28 by adding a `--omega-scans` option to the main `hveto` executable allowing the user to specify how many of the loudest glitches in each round to scan, default 0.