### PR TITLE
Pass --ifo to wdq-batch from hveto

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -756,7 +756,10 @@ if args.omega_scans:
     logger.info('Creating workflow for omega scans...')
     omegatimes = list(map(str, sorted(unique(
         [t['time'] for r in rounds for t in r.scans]))))
-    batch = ['wdq-batch'] + omegatimes + ['--output-dir', omegadir]
+    batch = ['wdq-batch'] + omegatimes + [
+        '--output-dir', omegadir,
+        '--ifo', ifo,
+    ]
     proc = subprocess.Popen(batch)
     out, err = proc.communicate()
     if proc.returncode:

--- a/hveto/tests/test_core.py
+++ b/hveto/tests/test_core.py
@@ -26,8 +26,9 @@ from common import unittest
 
 class HvetoRoundTestCase(unittest.TestCase):
     def test_init(self):
-        r = core.HvetoRound(1)
+        r = core.HvetoRound(1, 'X1:PRIMARY')
         self.assertEqual(r.n, 1)
+        self.assertEqual(r.primary, 'X1:PRIMARY')
 
 
 class CoreTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR fixes #50 by passing the `--ifo` argument to `wdq-batch` if creating an omega scan workflow.

The complete fix for #50 requires ligovirgo/gwdetchar#38 and ligovirgo/gwdetchar#39 to be merged and installed.