### PR TITLE
Sort events before return from get_triggers

### DIFF
--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -179,6 +179,7 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
         recarray = recfunctions.rec_append_fields(recarray, names, data)
         recarray = recfunctions.rec_drop_fields(recarray, dropfields)
 
+    recarray.sort(order='time')
     return recarray[columns]
 
 


### PR DESCRIPTION
This PR forces a time sorting of events returned by `get_triggers`, since many of the `hveto.core` methods require time ordering to work.

Fixes #55.