### PR TITLE
Fixed cache.sieve call in hveto-cache-events

### DIFF
--- a/bin/hveto-cache-events
+++ b/bin/hveto-cache-events
@@ -30,11 +30,6 @@ import os
 import warnings
 import multiprocessing
 
-try:
-    import configparser
-except ImportError:  # python 2.x
-    import ConfigParser as configparser
-
 from glue.lal import (Cache, CacheEntry)
 from glue.ligolw.ligolw import (Document, LIGO_LW, LIGOLWContentHandler)
 from glue.ligolw.utils import (write_filename as write_ligolw,

--- a/bin/hveto-cache-events
+++ b/bin/hveto-cache-events
@@ -177,7 +177,7 @@ def read_and_cache_events(channel, etg, cache=None, trigfindkwargs={},
     if cache is None:
         cache = find_trigger_files(channel, etg, new.active, **trigfindkwargs)
     else:
-        cache = cache.sieve(segments=new.active)
+        cache = cache.sieve(segmentlist=new.active)
     # restrict 'active' segments to when we have data
     try:
         new.active &= cache.to_segmentlistdict().values()[0]


### PR DESCRIPTION
This PR fixes a bug in `hveto-cache-events`.