### PR TITLE
Don't repeat completed omega scans

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -753,10 +753,15 @@ logger.debug("Summary JSON written to %s" % f.name)
 # -- generate workflow for omega scans
 
 if args.omega_scans:
-    logger.info('Creating workflow for omega scans...')
     omegatimes = list(map(str, sorted(unique(
         [t['time'] for r in rounds for t in r.scans]))))
-    batch = ['wdq-batch'] + omegatimes + [
+    logger.debug("Identified %d times for omega scan" % len(omegatimes))
+    newtimes = [t for t in omegatimes if not
+                utils.omega_scan_complete(os.path.join(omegadir, str(t)))]
+    logger.debug("%d scans already complete, %d remaining"
+                 % (len(omegatimes) - len(newtimes), len(newtimes)))
+    logger.info('Creating workflow for omega scans...')
+    batch = ['wdq-batch'] + newtimes + [
         '--output-dir', omegadir,
         '--ifo', ifo,
     ]

--- a/hveto/utils.py
+++ b/hveto/utils.py
@@ -21,6 +21,7 @@
 
 from __future__ import division
 
+import os.path
 from math import ceil
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -44,3 +45,36 @@ def channel_groups(channellist, ngroups):
     n = int(ceil(len(channellist) / ngroups))
     for i in range(0, len(channellist), n):
         yield channellist[i:i+n]
+
+
+def omega_scan_complete(scandir):
+    """Determine whether an omega scan was completed in the given directory
+
+    Parameters
+    ----------
+    scandir : `str`
+        output directory for a single omega scan
+
+    Returns
+    -------
+    complete : `bool`
+        `True` if the scan is considered complete, otherwise `False`
+
+    Notes
+    -----
+    The test is whether the final line of the `log.txt` file in the `scandir`
+    starts with 'finished on'.
+    """
+    logfile = os.path.join(scandir, 'log.txt')
+    try:
+        with open(logfile) as f:
+            f.seek(-2, 2)
+            while f.read(1) != b'\n':
+                f.seek(-2, 1)
+            line = f.readline()
+    except IOError:
+        return False
+    else:
+        if line.startswith('finished on '):
+            return True
+    return False


### PR DESCRIPTION
This PR fixes #58 by modifying `hveto` to check whether a proposed omega scan has been 'completed' already by checking the `log.txt` file in the scan directory.

This should help optimise the workflows a bit by not repeating scans.