### PR TITLE
Remove segments shorter than padding duration before padding

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -150,7 +150,7 @@ htmlv = {
 # get segments
 aflag = cp.get('segments', 'analysis-flag')
 url = cp.get('segments', 'url')
-padding = cp.getfloats('segments', 'padding')
+padding = tuple(cp.getfloats('segments', 'padding'))
 if args.analysis_segments:
     segs_ = DataQualityDict.read(args.analysis_segments, gpstype=float)
     analysis = segs_[aflag]
@@ -162,7 +162,12 @@ if args.analysis_segments:
 else:
     analysis = DataQualityFlag.query(aflag, start, end, url=url)
     logger.debug("Segments recovered from %s" % url)
-analysis.pad(*padding)
+if padding != (0, 0):
+    mindur = padding[0] - padding[1]
+    analysis.active = type(analysis.active)([s for s in analysis.active if
+                                             abs(s) >= mindur])
+    analysis.pad(*padding, inplace=True)
+    logger.debug("Padding %s applied" % str(padding))
 livetime = int(abs(analysis.active))
 livetimepc = livetime / duration * 100.
 logger.info("Retrieved %d segments for %s with %ss (%.2f%%) livetime"


### PR DESCRIPTION
This PR improves the way padding is applied to the analysis segments by pre-emptively removing those segments that are too short. This protects against a corner case of a short segment being mangled by the `glue.segments` logic.

Also, this PR modifies `hveto` to only execute the padding logic if a non-zero padding is actually given, a minor optimisation.