### PR TITLE
Added support for applying veto-definer file

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -54,7 +54,8 @@ from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 
 from hveto import (__version__, log, config, core, plot, html, utils)
-from hveto.segments import write_ascii as write_ascii_segments
+from hveto.segments import (write_ascii as write_ascii_segments,
+                            read_veto_definer_file)
 from hveto.triggers import (get_triggers, find_auxiliary_channels,
                             write_ascii as write_ascii_triggers)
 
@@ -167,6 +168,42 @@ livetime = int(abs(analysis.active))
 livetimepc = livetime / duration * 100.
 logger.info("Retrieved %d segments for %s with %ss (%.2f%%) livetime"
             % (len(analysis.active), aflag, livetime, livetimepc))
+
+# apply vetoes from veto-definer file
+try:
+    vetofile = cp.get('segments', 'veto-definer-file')
+except configparser.NoOptionError:
+    vetofile = None
+else:
+    try:
+        categories = cp.getfloats('segments', 'veto-definer-categories')
+    except configparser.NoOptionError:
+        categories = None
+    # read file
+    vdf = read_veto_definer_file(vetofile, start=start, end=end, ifo=ifo)
+    logger.debug("Read veto-definer file from %s" % vetofile)
+    # get vetoes from segdb
+    vdf.populate(source=url, segments=analysis.active, on_error='warn')
+    # coalesce flags from chosen categories
+    vetoes = DataQualityFlag('%s:VDF-VETOES:1' % ifo)
+    nflags = 0
+    for flag in vdf:
+        if not categories or vdf[flag].category in categories:
+            vetoes += vdf[flag]
+            nflags += 1
+    try:
+        deadtime = int(abs(vetoes.active)) / int(abs(vetoes.known)) * 100
+    except ZeroDivisionError:
+        deadtime = 0
+    logger.debug("Coalesced %ss (%.2f%%) of deadtime from %d veto flags"
+                 % (abs(vetoes.active), deadtime, nflags))
+    # apply to analysis segments
+    analysis -= vetoes
+    logger.debug("Applied vetoes from veto-definer file")
+    livetime = int(abs(analysis.active))
+    livetimepc = livetime / duration * 100.
+    logger.info("%ss (%.2f%%) livetime remaining after vetoes"
+                % (livetime, livetimepc))
 
 snrs = cp.getfloats('hveto', 'snr-thresholds')
 minsnr = min(snrs)

--- a/hveto/config.py
+++ b/hveto/config.py
@@ -138,14 +138,19 @@ Each of the below sections lists the valid options and a description of what the
 [segments]
 ----------
 
-=================  ============================================================
-``url``            The URL of the segment database
-``analysis-flag``  The name of the data-quality flag indicating analysable
-                   times
-``padding``        The `(pre, post)` padding to apply to the analysis segments
-                   [note both `pre` and `post` operate forward in time, so to
-                   pad out at the start of a segment, use a negative number]
-=================  ============================================================
+===========================  ==================================================
+``url``                      The URL of the segment database
+``analysis-flag``            The name of the data-quality flag indicating
+                             analysable times
+``padding``                  The `(pre, post)` padding to apply to the analysis
+                             segments [note both `pre` and `post` operate
+                             forward in time, so to pad out at the start of a
+                             segment (or in at the end), use a negative number]
+``veto-definer-file``        The path of a veto-definer file to apply before
+                             analysis (can be a remote URL)
+``veto-definer-categories``  Comma-separated list of category integers to
+                             apply, defaults to all flags in veto-definer file
+===========================  ==================================================
 
 .. code-block:: ini
 

--- a/hveto/segments.py
+++ b/hveto/segments.py
@@ -21,9 +21,12 @@
 
 from __future__ import print_function
 
+import os.path
 from functools import wraps
+from urlparse import urlparse
+from urllib2 import urlopen
 
-from gwpy.segments import DataQualityFlag, Segment, SegmentList
+from gwpy.segments import (DataQualityFlag, DataQualityDict)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Joshua Smith <joshua.smith@ligo.org>'
@@ -53,3 +56,15 @@ def write_ascii(outfile, segmentlist, ncol=4):
                 print("%f %f" % seg, file=f)
             else:
                 print("%d\t%f\t%f\t%f" % (i, seg[0], seg[1], abs(seg)), file=f)
+
+
+def read_veto_definer_file(vetofile, start=None, end=None, ifo=None):
+    """Read a veto definer file, downloading it if necessary
+    """
+    if urlparse(vetofile).netloc:
+        tmp = urlopen(vetofile)
+        vetofile = os.path.abspath(os.path.basename(vetofile))
+        with open(vetofile, 'w') as f:
+            f.write(tmp.read())
+    return DataQualityDict.from_veto_definer_file(
+        vetofile, format='ligolw', start=start, end=end, ifo=ifo)


### PR DESCRIPTION
This PR adds new configuration options in `[segments]` to allow vetoes from a veto-definer file to be applied to the analysis segments before the analysis. The new options are

```ini
[segments]
veto-definer-file = /path/or/url/to/veto-definer-file.xml
veto-definer-categories = comma, separated, list, of, categories
```