### PR TITLE
Update automatic auxiliary channel finding for Omicron O2 convention

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -237,6 +237,11 @@ try:
 except config.configparser.NoOptionError:
     auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo,
                                           cache=acache)
+    logger.debug("Auto-discovered %d auxiliary channels" % len(auxchannels))
+else:
+    auxchannels = sorted(set(auxchannels))
+    logger.debug("Read list of %d auxiliary channels" % len(auxchannels))
+
 
 # load unsafe channels list
 _unsafe = cp.get('safety', 'unsafe-channels')
@@ -255,10 +260,6 @@ else:  # or from line-seprated list
 unsafe.add(pchannel)
 cp.set('safety', 'unsafe-channels', '\n'.join(sorted(unsafe)))
 logger.debug("Read list of %d unsafe channels" % len(unsafe))
-
-# remove duplicates
-auxchannels = sorted(set(auxchannels))
-logger.debug("Read list of %d auxiliary channels" % len(auxchannels))
 
 # remove unsafe channels
 nunsafe = 0

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -220,14 +220,23 @@ def find_auxiliary_channels(etg, gps='*', ifo='*', cache=None):
             out.add(u'%s' % channel.rstrip('_'))
     else:
         channels = glob.glob(os.path.join(
-            '/home/detchar/triggers', '*', ifo, '*', str(gps)[:5]))
+            '/home/detchar/triggers', ifo, '*', str(gps)[:5]))
+        if len(channels) == 0:  # try old convention
+            channels = glob.glob(os.path.join(
+                '/home/detchar/triggers', '*', ifo, '*', str(gps)[:5]))
+            use_o2 = False
+        else:
+            use_o2 = True
         stub = '_%s' % etg.lower()
         for path in channels:
             path = os.path.split(path)[0]
             if not path.lower().endswith('_%s' % etg.lower()):
                 continue
             ifo, name = path[:-len(stub)].rsplit(os.path.sep)[-2:]
-            out.add(u'%s:%s' % (ifo, name))
+            if use_o2:
+                out.add(u'%s:%s' % (ifo, name.replace('_', '-', 1)))
+            else:
+                out.add(u'%s:%s' % (ifo, name))
     return sorted(out)
 
 


### PR DESCRIPTION
This PR updates the `triggers.find_auxiliary_channels` method to look for channel names using the O2 omicron conventions, and to fall-back on the pre-O2 conventions only if no channels are found.