### PR TITLE
Require matplotlib<2.0 for python-2.6 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 before_install:
   - pip install -q --upgrade pip
   # install specific packages for python2.6
-  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "scipy<0.18" "astropy<1.2"; fi
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "scipy<0.18" "astropy<1.2" "matplotlib<2.0"; fi
   - pip install ${PRE} -r requirements.txt
 
 install:


### PR DESCRIPTION
This PR updates the travis-ci configuration to force matplotlib<2.0 for python-2.6 - the mpl team dropped support for py26 with the new release.