### PR TITLE
Improved test coverage by running executables with --help

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,15 @@ before_install:
   - pip install ${PRE} -r requirements.txt
 
 install:
-  - pip install .
+  # note: need --editable for coverage with `which ...` to work
+  - pip install --editable .
 
 script:
   - pip install ${PRE} unittest2 coveralls "pytest>=2.8"
-  - coverage run --source=hveto --omit="hveto/tests/*,hveto/_version.py" ./setup.py test
-  - coverage run --append --source=hveto --omit="hveto/tests/*,hveto/_version.py" `which hveto` --help
+  - coverage run ./setup.py test
+  - coverage run --append `which hveto` --help
+  - coverage run --append `which hveto-cache-events` --help
+  - coverage run --append `which hveto-trace` --help
 
 after_success:
   - coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,9 @@ versionfile_source = hveto/_version.py
 versionfile_build = hveto/_version.py
 tag_prefix = v
 parentdir_prefix =
+
+[coverage:run]
+source = hveto
+omit =
+	hveto/tests/*
+	hveto/_version.py


### PR DESCRIPTION
This PR fixes the attempt to improve test coverage by running the executables with `--help` (hopefully).