### PR TITLE
Record auto-found aux channels in config with hveto executable

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -237,6 +237,7 @@ try:
 except config.configparser.NoOptionError:
     auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo,
                                           cache=acache)
+    cp.set('auxiliary', 'channels', '\n'.join(auxchannels))
     logger.debug("Auto-discovered %d auxiliary channels" % len(auxchannels))
 else:
     auxchannels = sorted(set(auxchannels))


### PR DESCRIPTION
This PR makes a one-line change to record the automatically-discovered auxiliary channel list (via `find_auxiliary_channels`) in the `ConfigParser` object so that it gets printed to the `How was this page generated?` HTML output.