### PR TITLE
Updated deprecated glue references

### DIFF
--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -28,7 +28,6 @@ import numpy
 from numpy.lib import recfunctions
 
 from glue.lal import Cache
-from glue.ligolw.table import StripTableName as strip_table_name
 
 from gwpy.table import lsctables
 
@@ -102,7 +101,7 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
     except KeyError as e:
         e.args = ('Unknown ETG %r, cannot map to LIGO_LW Table class' % etg,)
         raise
-    tablename = strip_table_name(Table.tableName)
+    tablename = Table.TableName(Table.tableName)
     # get default columns for this table
     if columns is None:
         for key in COLUMNS:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pykerberos
 m2crypto
 python-cjson
 https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
-http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
+http://software.ligo.org/lscsoft/source/glue-1.53.0.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 gwpy
 lxml


### PR DESCRIPTION
This PR updates `hveto.triggers` to not use `glue.ligolw` objects that have been removed in the latest release.