### PR TITLE
Search range of GPS directories in find_auxiliary_channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,29 @@ language: python
 
 addons:
   apt:
+    sources:
+      - sourceline: deb http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
+      - sourceline: deb-src http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
     packages:
       - gfortran  # scipy
       - libblas-dev  # scipy
       - liblapack-dev  # scipy
       - swig  # m2crypto
+      - pkg-config  # lal
+      - zlib1g-dev  # lal
+      - libgsl0-dev  # lal
+      - swig  # lal
+      - bc  # lal
+      - libfftw3-dev
+
+env:
+  global:
+    - LAL_VERSION="6.18.0"
 
 matrix:
   include:
-    - python: 2.6
-      env: PRE=""
     - python: 2.7
       env: PRE=""
     - python: 2.7
@@ -25,6 +38,7 @@ before_install:
   # install specific packages for python2.6
   - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "scipy<0.18" "astropy<1.2" "matplotlib<2.0"; fi
   - pip install ${PRE} -r requirements.txt
+  - .travis/build-lal.sh
 
 install:
   # note: need --editable for coverage with `which ...` to work
@@ -43,3 +57,5 @@ after_success:
 cache:
   apt: true
   pip: true
+  directories:
+    - lal-${LAL_VERSION}

--- a/.travis/build-lal.sh
+++ b/.travis/build-lal.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+set -x
+
+LAL_TAG="lal-${LAL_VERSION}"
+LAL_TARBALL="${LAL_TAG}.tar.xz"
+LAL_SOURCE="http://software.ligo.org/lscsoft/source/lalsuite"
+
+target=`python -c "import sys; print(sys.prefix)"`
+
+echo "----------------------------------------------------------------------"
+echo "Installing from ${LAL_TARBALL}"
+
+wget ${LAL_SOURCE}/${LAL_TARBALL} -O ${LAL_TARBALL} --quiet
+mkdir -p ${LAL_TAG}
+tar -xf ${LAL_TARBALL} --strip-components=1 -C ${LAL_TAG}
+cd ${LAL_TAG}
+./configure --enable-silent-rules --enable-swig-python --quiet --prefix=${target}
+make --silent
+make install --silent

--- a/bin/hveto
+++ b/bin/hveto
@@ -235,7 +235,7 @@ auxfreq = cp.getfloats('auxiliary', 'frequency-range')
 try:
     auxchannels = cp.get('auxiliary', 'channels').strip('\n').split('\n')
 except config.configparser.NoOptionError:
-    auxchannels = find_auxiliary_channels(auxetg, start, ifo=args.ifo,
+    auxchannels = find_auxiliary_channels(auxetg, (start, end), ifo=args.ifo,
                                           cache=acache)
     cp.set('auxiliary', 'channels', '\n'.join(auxchannels))
     logger.debug("Auto-discovered %d auxiliary channels" % len(auxchannels))


### PR DESCRIPTION
This PR fixes #69 by modifying the `triggers.find_auxiliary_channels` method to search through a range of GPS directories to match channel names. This will allow discovery of channels that only start populating the omicron archive mid-way through an analysis segment.

In order to get the CI working again, I also modified the build-and-test suite to install LAL.