### PR TITLE
Plot coincs on aux SNR vs time plot

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -589,6 +589,7 @@ cum. deadtime :   %s""" % (
     vetoedl = 'Vetoed\n[%d]' % vetoed.size
     beforeauxl = 'Before\n[%d]' % beforeaux.size
     usedl = 'Used\n[%d]' % winner.events.size
+    coincl = 'Coinc.\n[%d]' % coincs.size
     title = '%s Hveto round %d' % (ifo, round.n)
     ptitle = '%s: primary impact' % title
     atitle = '%s: auxiliary use' % title
@@ -649,9 +650,9 @@ cum. deadtime :   %s""" % (
     # snr versus time
     png = pngname % 'AUX_SNR_TIME'
     plot.veto_scatter(
-        png, beforeaux, winner.events, x='time', y='snr', label1=beforeauxl,
-        label2=usedl, epoch=start, xlim=[start, end], ylabel=statlabel,
-        title=atitle, subtitle=subtitle)
+        png, beforeaux, (winner.events, coincs), x='time', y='snr',
+        label1=beforeauxl, label2=(usedl, coincl), epoch=start,
+        xlim=[start, end], ylabel=statlabel, title=atitle, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
     round.plots.append(png)
 

--- a/bin/hveto
+++ b/bin/hveto
@@ -471,9 +471,9 @@ while True:
     # work out the vetoes for this round
     allaux = auxiliary[winner.name][
         auxiliary[winner.name]['snr'] >= winner.snr]
-    coincs = core.find_coincidences(allaux['time'], primary['time'],
-                                    dt=winner.window)
     winner.events = allaux
+    coincs = allaux[core.find_coincidences(allaux['time'], primary['time'],
+                                           dt=winner.window)]
     round.vetoes = winner.get_segments(allaux['time'])
     flag = DataQualityFlag(
         '%s:HVT-ROUND_%d:1' % (ifo, round.n), active=round.vetoes,

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -146,7 +146,7 @@ def veto_scatter(
         m = ax.scatter(a[x], a[y], c=a[color], label=label1, **colorargs)
         # add colorbar
         plot.add_colorbar(mappable=m, ax=ax, cmap=cmap, label=clabel)
-    if isinstance(b, list):
+    if isinstance(b, (list, tuple)):
         colors = list(rcParams['axes.prop_cycle'])
     else:
         b = [b]


### PR DESCRIPTION
This PR fixes #51 by adding the coincident aux events to the auxiliary SNR vs time plot. This now shows the following:

- black: all aux events
- blue: aux events chosen for veto that are _not_ coincident
- red: aux events chosen for veto that are coincident