### PR TITLE
Incremental improvements to reading ASCII events

### DIFF
--- a/hveto/config.py
+++ b/hveto/config.py
@@ -228,13 +228,11 @@ class HvetoConfigParser(configparser.ConfigParser):
             'snr-threshold': 8,
             'frequency-range': (30, 2048),
             'read-format': 'ligolw.sngl_burst',
-            'read-columns': 'time, peak_frequency, snr',
         },
         'auxiliary': {
             'trigger-generator': 'Omicron',
             'frequency-range': (30, 2048),
             'read-format': 'ligolw.sngl_burst',
-            'read-columns': 'time, peak_frequency, snr',
         },
         'safety': {
             'unsafe-channels': ['%(IFO)s:GDS-CALIB_STRAIN',

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -190,6 +190,12 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
                                                   'peak_frequency', 'snr'])
         read_kwargs.setdefault('get_as_columns', True)
 
+    # hacky fix for reading ASCII
+    #    astropy's ASCII reader uses `include_names` and not `columns`
+    if read_kwargs.get('format', '').startswith('ascii'):
+        read_kwargs.setdefault('include_names',
+                               read_kwargs.pop('columns', None))
+
     # find triggers
     if cache is None:
         cache = find_trigger_files(channel, etg, segments, **trigfind_kwargs)

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -200,6 +200,8 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
         else:
             outofbounds = abs(cachesegs - segaslist)
         if segcache:
+            if len(segcache) == 1:  # just pass the single filename
+                segcache = segcache[0].path
             new = EventTable.read(segcache, **read_kwargs)
             new.meta = {}  # we never need the metadata
             if outofbounds:

--- a/hveto/triggers.py
+++ b/hveto/triggers.py
@@ -183,6 +183,13 @@ def get_triggers(channel, etg, segments, cache=None, snr=None, frange=None,
             read_kwargs[key] = [x.strip(' ') for x in
                                       read_kwargs[key].split(',')]
 
+    # set default columns for sngl_burst table (Omicron)
+    if read_kwargs.get('format', '') == 'ligolw.sngl_burst':
+        read_kwargs.setdefault('columns', ['peak', 'peak_frequency', 'snr'])
+        read_kwargs.setdefault('ligolw_columns', ['peak_time', 'peak_time_ns',
+                                                  'peak_frequency', 'snr'])
+        read_kwargs.setdefault('get_as_columns', True)
+
     # find triggers
     if cache is None:
         cache = find_trigger_files(channel, etg, segments, **trigfind_kwargs)


### PR DESCRIPTION
This PR improves the ability of `hveto` to read arbitrary inputs via `hveto.triggers.get_triggers` with a few changes

- [4748196] unwrap a cache of a single file into just a filename
- [ca7ab6e] moved default column setting from `hveto.config` into `hveto.triggers` to simplify reading ASCII
- [c94683d] work around kwarg name differences between reading LIGO_LW and ASCII with gwpy's EventTable

All of this means that ASCII files can be passed as the primary input using `--primary-cache` and the following configuration 

```ini
[primary]
trigger-generator = Gravity Spy
read-format = ascii.csv
```

NB: when reading with `--primary-cache`, the `trigger-generator` option is not actually used for anything, but its useful for self-documentation of the configuration.