### PR TITLE
Added 'coinc' datasets to all aux plots

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -648,8 +648,8 @@ cum. deadtime :   %s""" % (
     # snr versus frequency
     png = pngname % 'AUX_SNR_FREQUENCY'
     plot.veto_scatter(
-        png, beforeaux, winner.events, x=auxfcol, y=auxscol,
-        label1=beforeauxl, label2=usedl, xlabel=auxflabel,
+        png, beforeaux, (winner.events, coincs), x=auxfcol, y=auxscol,
+        label1=beforeauxl, label2=(usedl, coincl), xlabel=auxflabel,
         ylabel=auxslabel, title=atitle, subtitle=subtitle, legend_title="Aux:")
     logger.debug("Figure written to %s" % png)
     round.plots.append(png)
@@ -657,10 +657,10 @@ cum. deadtime :   %s""" % (
     # frequency versus time coloured by SNR
     png = pngname % 'AUX_FREQUENCY_TIME'
     plot.veto_scatter(
-        png, beforeaux, winner.events, x='time', y=auxfcol, color=auxscol,
-        label1=None, label2=None, ylabel=auxflabel, clabel=auxslabel,
-        clim=[3, 100], cmap='YlGnBu', epoch=start, xlim=[start, end],
-        title=atitle, subtitle=subtitle)
+        png, beforeaux, (winner.events, coincs), x='time', y=auxfcol,
+        color=auxscol, label1=None, label2=[None, None], ylabel=auxflabel,
+        clabel=auxslabel, clim=[3, 100], cmap='YlGnBu', epoch=start,
+        xlim=[start, end], title=atitle, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
     round.plots.append(png)
 

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -152,7 +152,13 @@ def veto_scatter(
         m = ax.scatter(a[x], a[ya], c=a[color], label=label1, **colorargs)
         # add colorbar
         plot.add_colorbar(mappable=m, ax=ax, cmap=cmap, label=clabel)
-    if isinstance(b, (list, tuple)):
+    if isinstance(b, (list, tuple)) and len(b) == 2:
+        # aux channel used/coinc (probably)
+        colors = [{'color': c} for c in (
+            '#ffd200',  # yellow
+            '#d62728',  # red
+        )]
+    elif isinstance(b, (list, tuple)):
         colors = list(rcParams['axes.prop_cycle'])
     else:
         b = [b]


### PR DESCRIPTION
This PR essentially duplicates #71 for other figures, with the 'used' dataset now shown in yellow, and the 'coinc' set in red. This allows better contrast with the blue-green-yellow colour map for the event trigger scatter plots.