### PR TITLE
Updated requirements.txt to require glue/dqsegdb from pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       - gfortran  # scipy
       - libblas-dev  # scipy
       - liblapack-dev  # scipy
-      - swig  # m2crypto
       - pkg-config  # lal
       - zlib1g-dev  # lal
       - libgsl0-dev  # lal

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,8 @@ scipy
 gitpython
 jinja2
 pykerberos
-m2crypto
-python-cjson
 https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
-http://software.ligo.org/lscsoft/source/glue-1.53.0.tar.gz
-http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
+lscsoft-glue
+dqsegdb
 gwpy
 lxml


### PR DESCRIPTION
This PR updates `requirements.txt` and the travis-ci configuration to pull in `glue` and `dqsegdb` from pypi.python.org, rather than software.ligo.org, since those projects are now registered there.