### PR TITLE
Adding customized figure captions to Hveto pages

### DIFF
--- a/bin/hveto
+++ b/bin/hveto
@@ -53,6 +53,7 @@ from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 
 from hveto import (__version__, log, config, core, plot, html, utils)
+from hveto.plot import (HEADER_CAPTION, ROUND_CAPTION, FancyPlot)
 from hveto.segments import (write_ascii as write_ascii_segments,
                             read_veto_definer_file)
 from hveto.triggers import (get_triggers, find_auxiliary_channels,
@@ -456,6 +457,7 @@ while True:
         plot.significance_drop(png, oldsignificances, newsignificances,
                                title=title, subtitle=subtitle)
         logger.debug("Figure written to %s" % png)
+        png = FancyPlot(png, caption=ROUND_CAPTION['SIG_DROP'])
         rounds[-1].plots.append(png)
     oldsignificances = newsignificances
 
@@ -596,6 +598,7 @@ cum. deadtime :   %s""" % (
         label1=beforel, label2=afterl, xlabel=slabel,
         title=ptitle, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['HISTOGRAM'])
     round.plots.append(png)
 
     # snr versus time
@@ -605,6 +608,7 @@ cum. deadtime :   %s""" % (
         epoch=start, xlim=[start, end], ylabel=slabel,
         title=ptitle, subtitle=subtitle, legend_title="Primary:")
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['SNR_TIME'])
     round.plots.append(png)
 
     # snr versus frequency
@@ -614,6 +618,7 @@ cum. deadtime :   %s""" % (
         label2=vetoedl, xlabel=flabel, ylabel=slabel, xlim=pfreq,
         title=ptitle, subtitle=subtitle, legend_title="Primary:")
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['SNR'])
     round.plots.append(png)
 
     # frequency versus time coloured by SNR
@@ -625,6 +630,7 @@ cum. deadtime :   %s""" % (
         epoch=start, xlim=[start, end], ylim=pfreq,
         title=ptitle, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['TIME'])
     round.plots.append(png)
 
     # aux used versus frequency
@@ -634,6 +640,7 @@ cum. deadtime :   %s""" % (
         label2=vetoedl, ylabel=slabel, epoch=start, xlim=[start, end],
         title=atitle, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['USED_SNR_TIME'])
     round.plots.append(png)
 
     # snr versus time
@@ -643,6 +650,7 @@ cum. deadtime :   %s""" % (
         label1=beforeauxl, label2=(usedl, coincl), epoch=start,
         xlim=[start, end], ylabel=auxslabel, title=atitle, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['AUX_SNR_TIME'])
     round.plots.append(png)
 
     # snr versus frequency
@@ -652,6 +660,7 @@ cum. deadtime :   %s""" % (
         label1=beforeauxl, label2=(usedl, coincl), xlabel=auxflabel,
         ylabel=auxslabel, title=atitle, subtitle=subtitle, legend_title="Aux:")
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['AUX_SNR_FREQUENCY'])
     round.plots.append(png)
 
     # frequency versus time coloured by SNR
@@ -662,6 +671,7 @@ cum. deadtime :   %s""" % (
         clabel=auxslabel, clim=[3, 100], cmap='YlGnBu', epoch=start,
         xlim=[start, end], title=atitle, subtitle=subtitle)
     logger.debug("Figure written to %s" % png)
+    png = FancyPlot(png, caption=ROUND_CAPTION['AUX_FREQUENCY_TIME'])
     round.plots.append(png)
 
     # move to the next round
@@ -708,12 +718,14 @@ plot.before_after_histogram(
     png, pevents[0][scol], pevents[-1][scol],
     label1=beforel, label2=afterl, xlabel=slabel,
     title=title, subtitle=subtitle)
+png = FancyPlot(png, caption=HEADER_CAPTION['HISTOGRAM'])
 plots.append(png)
 logger.debug("Figure written to %s" % png)
 
 # efficiency/deadtime curve
 png = pngname % 'ROC'
 plot.hveto_roc(png, rounds, title=title, subtitle=subtitle)
+png = FancyPlot(png, caption=HEADER_CAPTION['ROC'])
 plots.append(png)
 logger.debug("Figure written to %s" % png)
 
@@ -726,6 +738,7 @@ plot.veto_scatter(
     label1='', label2=labels, title=title,
     subtitle=subtitle, ylabel=flabel, x='time', y=fcol,
     epoch=start, xlim=[start, end], legend_title=legtitle)
+png = FancyPlot(png, caption=HEADER_CAPTION['TIME'])
 plots.append(png)
 logger.debug("Figure written to %s" % png)
 
@@ -735,6 +748,7 @@ plot.veto_scatter(
     png, pevents[0], pvetoed, label1='', label2=labels, title=title,
     subtitle=subtitle, ylabel=slabel, x='time', y=scol,
     epoch=start, xlim=[start, end], legend_title=legtitle)
+png = FancyPlot(png, caption=HEADER_CAPTION['SNR_TIME'])
 plots.append(png)
 logger.debug("Figure written to %s" % png)
 

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -691,13 +691,14 @@ def write_round(round):
     # plots
     page.div(class_='col-md-9', id_='hveto-round-%d-plots' % round.n)
     pparams = dict()
-    for i, p in enumerate(round.plots):
+    for i, p in enumerate(round.plots[:-1]):
         pparams[p] = {'title': round_captions[i]}
-    page.add(scaffold_plots(round.plots[:-1], nperrow=4, pparams=pparams[:-1]))
+    page.add(scaffold_plots(round.plots[:-1], nperrow=4, pparams=pparams))
     # add significance drop plot at end
     page.div(class_='row')
     page.div(class_='col-sm-12')
-    page.add(fancybox_img(round.plots[-1], pparams=pparams[-1]))
+    page.add(fancybox_img(round.plots[-1],
+                          pparams={'title': round_captions[-1]}))
     page.div.close()  # col-sm-12
     page.div.close()  # row
     page.div.close()  # col-md-8

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -92,78 +92,92 @@ $(document).ready(function() {
 
 # -- set up default header plot captions
 
-head_hist = "Histogram of number of triggers in the primary channel before " \
-    "the hveto analysis, but after the data quality flag cuts (red) compared " \
-    "with the number after vetoes from all hveto rounds have been applied " \
-    "(blue) versus the signal-to-noise ratio of those triggers."
-head_roc = "The fraction of the primary channel triggers vetoed (fractional " \
-    "efficiency) versus the fraction of livetime that is vetoed (fractional " \
-    "deadtime) for each hveto round (blue dots). Guidelines are given for " \
-    "efficiency/deadtime of 1 (the value expected for random chance) and higher."
-head_freq = "Frequency versus time graph of all triggers in the primary " \
-    "channel before the hveto analysis (black dots) and those triggers that are " \
-    "vetoed by a given round (symbols)."
-head_snr = "Signal-to-noise ratio versus time graph of all triggers in the " \
-    "primary channel before the hveto analysis (black dots) and those triggers " \
-    "that are vetoed by a given round (symbols)."
-head_captions = [head_hist, head_roc, head_freq, head_snr]
-
+HEADER_CAPTIONS = [
+    # histogram of triggers
+    "Histogram of number of triggers in the primary channel before the hveto "
+    "analysis, but after the data quality flag cuts (red) compared with the "
+    "number after vetoes from all hveto rounds have been applied (blue) "
+    "versus the signal-to-noise ratio of those triggers.",
+    # ROC curve
+    "The fraction of the primary channel triggers vetoed (fractional "
+    "efficiency) versus the fraction of livetime that is vetoed (fractional "
+    "deadtime) for each hveto round (blue dots). Guidelines are given for "
+    "efficiency/deadtime of 1 (the value expected for random chance) and "
+    "higher.",
+    # trigger frequency vs. time
+    "Frequency versus time graph of all triggers in the primary channel "
+    "before the hveto analysis (black dots) and those triggers that are "
+    "vetoed by a given round (symbols).",
+    # SNR timeseries
+    "Signal-to-noise ratio versus time graph of all triggers in the primary "
+    "channel before the hveto analysis (black dots) and those triggers that "
+    "are vetoed by a given round (symbols)."
+]
 
 # -- set up default round winner plot captions
 
-round_hist = "Histogram of number of triggers in the primary channel before " \
-    "this round of hveto (red) compared with the number after vetoes from this " \
-    "round have been applied (blue) versus the signal-to-noise ratio of those " \
-    "triggers."
-round_snr_time = "Signal-to-noise ratio versus time graph of all triggers " \
-    "in the primary channel before this round of hveto (black dots) and those " \
-    "triggers that are vetoed by this round (red plusses)."
-round_snr_freq = "Signal-to-noise ratio versus frequency graph of all " \
-    "triggers in the primary channel before this round of hveto (black dots) " \
-    "and those triggers that are vetoed by this round (red plusses)."
-round_freq = "Frequency versus time graph of all triggers in the primary " \
-    "channel before this hveto round (dots colored by signal-to-noise ratio) " \
-    "and those triggers that are vetoed by this round (red plusses)."
-round_used_snr = "Signal-to-noise ratio versus time graph of all triggers " \
-    "in the auxiliary channel above the threshold selected for this round " \
-    "(black dots, these are the triggers used to construct the veto) and the " \
-    "primary channel triggers that are vetoed in this round (red plusses). This " \
-    "cand indicate whether, for example, louder triggers in the auxiliary " \
-    "channel are used to veto quieter channels in the primary channel, as might " \
-    "be expected for an external disturbance."
-round_aux_snr = "Signal-to-noise ratio versus time graph of all triggers in " \
-    "the auxiliary channel before this round (black dots), those above the " \
-    "threshold selected for this round (yellow plusses, these are the triggers " \
-    "used to construct the veto), and those triggers that actually veto one of " \
-    "the primary channel triggers (red plusses)."
-round_aux_snr_freq = "Signal-to-noise ratio versus frequency graph of all " \
-    "triggers in the auxiliary channel before this round (black dots), those " \
-    "above the threshold selected for this round (yellow plusses, these are the " \
-    "triggers used to construct the veto), and those triggers that actually " \
+ROUND_CAPTIONS = [
+    # histogram of triggers
+    "Histogram of number of triggers in the primary channel before this round "
+    "of hveto (red) compared with the number after vetoes from this round "
+    "have been applied (blue) versus the signal-to-noise ratio of those "
+    "triggers.",
+    # SNR timeseries
+    "Signal-to-noise ratio versus time graph of all triggers in the primary "
+    "channel before this round of hveto (black dots) and those triggers that "
+    "are vetoed by this round (red plusses).",
+    # SNR frequencyseries
+    "Signal-to-noise ratio versus frequency graph of all triggers in the "
+    "primary channel before this round of hveto (black dots) and those "
+    "triggers that are vetoed by this round (red plusses).",
+    # trigger frequency vs. time
+    "Frequency versus time graph of all triggers in the primary channel "
+    "before this hveto round (dots colored by signal-to-noise ratio) and "
+    "those triggers that are vetoed by this round (red plusses).",
+    # used SNR timeseries
+    "Signal-to-noise ratio versus time graph of all triggers in the auxiliary "
+    "channel above the threshold selected for this round (black dots, these "
+    "are the triggers used to construct the veto) and the primary channel "
+    "triggers that are vetoed in this round (red plusses). This can indicate "
+    "whether, for example, louder triggers in the auxiliary channel are used "
+    "to veto quieter channels in the primary channel, as might be expected "
+    "for an external disturbance.",
+    # all auxiliary SNR timeseries
+    "Signal-to-noise ratio versus time graph of all triggers in the auxiliary "
+    "channel before this round (black dots), those above the threshold "
+    "selected for this round (yellow plusses, these are the triggers used to "
+    "construct the veto), and those triggers that actually veto one of the "
+    "primary channel triggers (red plusses).",
+    # all auxiliary SNR frequencyseries
+    "Signal-to-noise ratio versus frequency graph of all triggers in the "
+    "auxiliary channel before this round (black dots), those above the "
+    "threshold selected for this round (yellow plusses, these are the "
+    "triggers used to construct the veto), and those triggers that actually "
+    "veto one of the primary channel triggers (red plusses).",
+    # all auxiliary trigger frequency vs. time
+    "Frequency versus time graph of all triggers in the auxiliary channel "
+    "before this round (dots colored by signal-to-noise ratio), those above "
+    "the threshold selected for this round (yellow plusses, these are the "
+    "triggers used to construct the veto), and those triggers that actually "
     "veto one of the primary channel triggers (red plusses)."
-round_aux_freq = "Frequency versus time graph of all triggers in the " \
-    "auxiliary channel before this round (dots colored by signal-to-noise ratio), " \
-    "those above the threshold selected for this round (yellow plusses, these are " \
-    "the triggers used to construct the veto), and those triggers that actually " \
-    "veto one of the primary channel triggers (red plusses)."
-round_sig_drop = "This plot includes interactive features (channel names " \
-    "appear when pointed to with your mouse cursor) that can be accessed by " \
-    "opening the plot in a new tab. The statistical significance value (based on " \
-    "Poisson statistics) for the best SNR and time window combination for each " \
-    "auxiliary channel before and after this round are shown as a baton. The " \
-    "round’s winning channel, which had the highest significance, is shown in " \
-    "yellow. The top of the yellow baton is the significance of this channel " \
-    "before this round and the bottom of the baton is its significance in the " \
-    "next round, after its triggers above this round’s SNR threshold and time " \
-    "window have been removed (note that this channel may have nonzero " \
-    "significance in the next round because it may still have triggers left at " \
-    "a lower SNR threshold). Blue batons are for channels whose significance " \
-    "dropped after this round (indicating that that channel had some trigger " \
-    "times in common with the winner) and red batons are for channels whose " \
+]
+
+ROUND_SIG_DROP_CAPTION = "This plot includes interactive features (channel " \
+    "names appear when pointed to with your mouse cursor) that can be " \
+    "accessed by opening the plot in a new tab. The statistical " \
+    "significance value (based on Poisson statistics) for the best SNR and " \
+    "time window combination for each auxiliary channel before and after " \
+    "this round are shown as a baton. The round’s winning channel, which " \
+    "had the highest significance, is shown in yellow. The top of the " \
+    "yellow baton is the significance of this channel before this round and " \
+    "the bottom of the baton is its significance in the next round, after " \
+    "its triggers above this round’s SNR threshold and time window have " \
+    "been removed (note that this channel may have nonzero significance in " \
+    "the next round because it may still have triggers left at a lower SNR " \
+    "threshold). Blue batons are for channels whose significance dropped " \
+    "after this round (indicating that that channel had some trigger times " \
+    "in common with the winner) and red batons are for channels whose " \
     "significance increased in the next round (due to less livetime)."
-round_captions = [round_hist, round_snr_time, round_snr_freq,
-                  round_freq, round_used_snr, round_aux_snr,
-                  round_aux_snr_freq, round_aux_freq]
 
 
 # -- HTML construction --------------------------------------------------------
@@ -666,7 +680,7 @@ def write_summary(
     if plots:
         pparams = dict()
         for i, p in enumerate(plots):
-            pparams[p] = {'title': head_captions[i]}
+            pparams[p] = {'title': HEADER_CAPTIONS[i]}
         page.add(scaffold_plots(plots, nperrow=plotsperrow, pparams=pparams))
     return page()
 
@@ -743,13 +757,13 @@ def write_round(round):
     page.div(class_='col-md-9', id_='hveto-round-%d-plots' % round.n)
     pparams = dict()
     for i, p in enumerate(round.plots[:-1]):
-        pparams[p] = {'title': round_captions[i]}
+        pparams[p] = {'title': ROUND_CAPTIONS[i]}
     page.add(scaffold_plots(round.plots[:-1], nperrow=4, pparams=pparams))
     # add significance drop plot at end
     page.div(class_='row')
     page.div(class_='col-sm-12')
     page.add(fancybox_img(round.plots[-1],
-                          linkparams={'title': round_sig_drop}))
+                          linkparams={'title': ROUND_SIG_DROP_CAPTION}))
     page.div.close()  # col-sm-12
     page.div.close()  # row
     page.div.close()  # col-md-8

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -33,7 +33,7 @@ from glue import markup
 from _version import get_versions
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-__credits__ = 'Josh Smith, Joe Areeda'
+__credits__ = 'Josh Smith, Joe Areeda, Alex Urban'
 
 # -- set up default JS and CSS files
 

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -112,7 +112,7 @@ round_aux_freq = "Frequency versus time graph of all triggers in the auxiliary c
 round_sig_drop = "This plot includes interactive features (channel names appear when pointed to with your mouse cursor) that can be accessed by opening the plot in a new tab. The statistical significance value (based on Poisson statistics) for the best SNR and time window combination for each auxiliary channel before and after this round are shown as a baton. The round’s winning channel, which had the highest significance, is shown in yellow. The top of the yellow baton is the significance of this channel before this round and the bottom of the baton is its significance in the next round, after its triggers above this round’s SNR threshold and time window have been removed (note that this channel may have nonzero significance in the next round because it may still have triggers left at a lower SNR threshold). Blue batons are for channels whose significance dropped after this round (indicating that that channel had some trigger times in common with the winner) and red batons are for channels whose significance increased in the next round (due to less livetime)."
 round_captions = [round_hist, round_snr_time, round_snr_freq,
                   round_freq, round_used_snr, round_aux_snr,
-                  round_aux_snr_freq, round_aux_freq, round_sig_drop]
+                  round_aux_snr_freq, round_aux_freq]
 
 
 # -- HTML construction --------------------------------------------------------
@@ -698,7 +698,7 @@ def write_round(round):
     page.div(class_='row')
     page.div(class_='col-sm-12')
     page.add(fancybox_img(round.plots[-1],
-                          pparams={'title': round_captions[-1]}))
+                          pparams={'title': round_sig_drop}))
     page.div.close()  # col-sm-12
     page.div.close()  # row
     page.div.close()  # col-md-8

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -92,75 +92,75 @@ $(document).ready(function() {
 
 # -- set up default header plot captions
 
-head_hist = "Histogram of number of triggers in the primary channel before "
-"the hveto analysis, but after the data quality flag cuts (red) compared "
-"with the number after vetoes from all hveto rounds have been applied "
-"(blue) versus the signal-to-noise ratio of those triggers."
-head_roc = "The fraction of the primary channel triggers vetoed (fractional "
-"efficiency) versus the fraction of livetime that is vetoed (fractional "
-"deadtime) for each hveto round (blue dots). Guidelines are given for "
-"efficiency/deadtime of 1 (the value expected for random chance) and higher."
-head_freq = "Frequency versus time graph of all triggers in the primary "
-"channel before the hveto analysis (black dots) and those triggers that are "
-"vetoed by a given round (symbols)."
-head_snr = "Signal-to-noise ratio versus time graph of all triggers in the "
-"primary channel before the hveto analysis (black dots) and those triggers "
-"that are vetoed by a given round (symbols)."
+head_hist = "Histogram of number of triggers in the primary channel before " \
+    "the hveto analysis, but after the data quality flag cuts (red) compared " \
+    "with the number after vetoes from all hveto rounds have been applied " \
+    "(blue) versus the signal-to-noise ratio of those triggers."
+head_roc = "The fraction of the primary channel triggers vetoed (fractional " \
+    "efficiency) versus the fraction of livetime that is vetoed (fractional " \
+    "deadtime) for each hveto round (blue dots). Guidelines are given for " \
+    "efficiency/deadtime of 1 (the value expected for random chance) and higher."
+head_freq = "Frequency versus time graph of all triggers in the primary " \
+    "channel before the hveto analysis (black dots) and those triggers that are " \
+    "vetoed by a given round (symbols)."
+head_snr = "Signal-to-noise ratio versus time graph of all triggers in the " \
+    "primary channel before the hveto analysis (black dots) and those triggers " \
+    "that are vetoed by a given round (symbols)."
 head_captions = [head_hist, head_roc, head_freq, head_snr]
 
 
 # -- set up default round winner plot captions
 
-round_hist = "Histogram of number of triggers in the primary channel before "
-"this round of hveto (red) compared with the number after vetoes from this "
-"round have been applied (blue) versus the signal-to-noise ratio of those "
-"triggers."
-round_snr_time = "Signal-to-noise ratio versus time graph of all triggers in "
-"the primary channel before this round of hveto (black dots) and those "
-"triggers that are vetoed by this round (red plusses)."
-round_snr_freq = "Signal-to-noise ratio versus frequency graph of all "
-"triggers in the primary channel before this round of hveto (black dots) and "
-"those triggers that are vetoed by this round (red plusses)."
-round_freq = "Frequency versus time graph of all triggers in the primary "
-"channel before this hveto round (dots colored by signal-to-noise ratio) and "
-"those triggers that are vetoed by this round (red plusses)."
-round_used_snr = "Signal-to-noise ratio versus time graph of all triggers in "
-"the auxiliary channel above the threshold selected for this round (black "
-"dots, these are the triggers used to construct the veto) and the primary "
-"channel triggers that are vetoed in this round (red plusses). This can "
-"indicate whether, for example, louder triggers in the auxiliary channel are "
-"used to veto quieter channels in the primary channel, as might be expected "
-"for an external disturbance."
-round_aux_snr = "Signal-to-noise ratio versus time graph of all triggers in "
-"the auxiliary channel before this round (black dots), those above the "
-"threshold selected for this round (yellow plusses, these are the triggers "
-"used to construct the veto), and those triggers that actually veto one of the "
-"primary channel triggers (red plusses)."
-round_aux_snr_freq = "Signal-to-noise ratio versus frequency graph of all "
-"triggers in the auxiliary channel before this round (black dots), those above "
-"the threshold selected for this round (yellow plusses, these are the triggers "
-"used to construct the veto), and those triggers that actually veto one of the "
-"primary channel triggers (red plusses)."
-round_aux_freq = "Frequency versus time graph of all triggers in the auxiliary "
-"channel before this round (dots colored by signal-to-noise ratio), those "
-"above the threshold selected for this round (yellow plusses, these are the "
-"triggers used to construct the veto), and those triggers that actually veto "
-"one of the primary channel triggers (red plusses)."
-round_sig_drop = "This plot includes interactive features (channel names "
-"appear when pointed to with your mouse cursor) that can be accessed by "
-"opening the plot in a new tab. The statistical significance value (based on "
-"Poisson statistics) for the best SNR and time window combination for each "
-"auxiliary channel before and after this round are shown as a baton. The "
-"round’s winning channel, which had the highest significance, is shown in "
-"yellow. The top of the yellow baton is the significance of this channel "
-"before this round and the bottom of the baton is its significance in the next "
-"round, after its triggers above this round’s SNR threshold and time window "
-"have been removed (note that this channel may have nonzero significance in "
-"the next round because it may still have triggers left at a lower SNR "
-"threshold). Blue batons are for channels whose significance dropped after "
-"this round (indicating that that channel had some trigger times in common "
-"with the winner) and red batons are for channels whose significance increased "
-"in the next round (due to less livetime)."
+round_hist = "Histogram of number of triggers in the primary channel before " \
+    "this round of hveto (red) compared with the number after vetoes from this " \
+    "round have been applied (blue) versus the signal-to-noise ratio of those " \
+    "triggers."
+round_snr_time = "Signal-to-noise ratio versus time graph of all triggers " \
+    "in the primary channel before this round of hveto (black dots) and those " \
+    "triggers that are vetoed by this round (red plusses)."
+round_snr_freq = "Signal-to-noise ratio versus frequency graph of all " \
+    "triggers in the primary channel before this round of hveto (black dots) " \
+    "and those triggers that are vetoed by this round (red plusses)."
+round_freq = "Frequency versus time graph of all triggers in the primary " \
+    "channel before this hveto round (dots colored by signal-to-noise ratio) " \
+    "and those triggers that are vetoed by this round (red plusses)."
+round_used_snr = "Signal-to-noise ratio versus time graph of all triggers " \
+    "in the auxiliary channel above the threshold selected for this round " \
+    "(black dots, these are the triggers used to construct the veto) and the " \
+    "primary channel triggers that are vetoed in this round (red plusses). This " \
+    "cand indicate whether, for example, louder triggers in the auxiliary " \
+    "channel are used to veto quieter channels in the primary channel, as might " \
+    "be expected for an external disturbance."
+round_aux_snr = "Signal-to-noise ratio versus time graph of all triggers in " \
+    "the auxiliary channel before this round (black dots), those above the " \
+    "threshold selected for this round (yellow plusses, these are the triggers " \
+    "used to construct the veto), and those triggers that actually veto one of " \
+    "the primary channel triggers (red plusses)."
+round_aux_snr_freq = "Signal-to-noise ratio versus frequency graph of all " \
+    "triggers in the auxiliary channel before this round (black dots), those " \
+    "above the threshold selected for this round (yellow plusses, these are the " \
+    "triggers used to construct the veto), and those triggers that actually " \
+    "veto one of the primary channel triggers (red plusses)."
+round_aux_freq = "Frequency versus time graph of all triggers in the " \
+    "auxiliary channel before this round (dots colored by signal-to-noise ratio), " \
+    "those above the threshold selected for this round (yellow plusses, these are " \
+    "the triggers used to construct the veto), and those triggers that actually " \
+    "veto one of the primary channel triggers (red plusses)."
+round_sig_drop = "This plot includes interactive features (channel names " \
+    "appear when pointed to with your mouse cursor) that can be accessed by " \
+    "opening the plot in a new tab. The statistical significance value (based on " \
+    "Poisson statistics) for the best SNR and time window combination for each " \
+    "auxiliary channel before and after this round are shown as a baton. The " \
+    "round’s winning channel, which had the highest significance, is shown in " \
+    "yellow. The top of the yellow baton is the significance of this channel " \
+    "before this round and the bottom of the baton is its significance in the " \
+    "next round, after its triggers above this round’s SNR threshold and time " \
+    "window have been removed (note that this channel may have nonzero " \
+    "significance in the next round because it may still have triggers left at " \
+    "a lower SNR threshold). Blue batons are for channels whose significance " \
+    "dropped after this round (indicating that that channel had some trigger " \
+    "times in common with the winner) and red batons are for channels whose " \
+    "significance increased in the next round (due to less livetime)."
 round_captions = [round_hist, round_snr_time, round_snr_freq,
                   round_freq, round_used_snr, round_aux_snr,
                   round_aux_snr_freq, round_aux_freq]

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -114,6 +114,7 @@ HEADER_CAPTIONS = [
     "are vetoed by a given round (symbols)."
 ]
 
+
 # -- set up default round winner plot captions
 
 ROUND_CAPTIONS = [

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -375,7 +375,7 @@ def fancybox_img(img, linkparams=dict(), **params):
 
     Parameters
     ----------
-    img : `str`
+    img : `FancyPlot`
         a `FancyPlot` object containing the path of the image to embed
         and its caption to be displayed
     linkparams : `dict`
@@ -386,6 +386,10 @@ def fancybox_img(img, linkparams=dict(), **params):
     Returns
     -------
     html : `str`
+
+    Notes
+    -----
+    See `~hveto.plot.FancyPlot` for more about the `FancyPlot` class.
     """
     page = markup.page()
     aparams = {

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -92,24 +92,75 @@ $(document).ready(function() {
 
 # -- set up default header plot captions
 
-head_hist = "Histogram of number of triggers in the primary channel before the hveto analysis, but after the data quality flag cuts (red) compared with the number after vetoes from all hveto rounds have been applied (blue) versus the signal-to-noise ratio of those triggers."
-head_roc = "The fraction of the primary channel triggers vetoed (fractional efficiency) versus the fraction of livetime that is vetoed (fractional deadtime) for each hveto round (blue dots). Guidelines are given for efficiency/deadtime of 1 (the value expected for random chance) and higher."
-head_freq = "Frequency versus time graph of all triggers in the primary channel before the hveto analysis (black dots) and those triggers that are vetoed by a given round (symbols)."
-head_snr = "Signal-to-noise ratio versus time graph of all triggers in the primary channel before the hveto analysis (black dots) and those triggers that are vetoed by a given round (symbols)."
+head_hist = "Histogram of number of triggers in the primary channel before "
+"the hveto analysis, but after the data quality flag cuts (red) compared "
+"with the number after vetoes from all hveto rounds have been applied "
+"(blue) versus the signal-to-noise ratio of those triggers."
+head_roc = "The fraction of the primary channel triggers vetoed (fractional "
+"efficiency) versus the fraction of livetime that is vetoed (fractional "
+"deadtime) for each hveto round (blue dots). Guidelines are given for "
+"efficiency/deadtime of 1 (the value expected for random chance) and higher."
+head_freq = "Frequency versus time graph of all triggers in the primary "
+"channel before the hveto analysis (black dots) and those triggers that are "
+"vetoed by a given round (symbols)."
+head_snr = "Signal-to-noise ratio versus time graph of all triggers in the "
+"primary channel before the hveto analysis (black dots) and those triggers "
+"that are vetoed by a given round (symbols)."
 head_captions = [head_hist, head_roc, head_freq, head_snr]
 
 
 # -- set up default round winner plot captions
 
-round_hist = "Histogram of number of triggers in the primary channel before this round of hveto (red) compared with the number after vetoes from this round have been applied (blue) versus the signal-to-noise ratio of those triggers."
-round_snr_time = "Signal-to-noise ratio versus time graph of all triggers in the primary channel before this round of hveto (black dots) and those triggers that are vetoed by this round (red plusses)."
-round_snr_freq = "Signal-to-noise ratio versus frequency graph of all triggers in the primary channel before this round of hveto (black dots) and those triggers that are vetoed by this round (red plusses)."
-round_freq = "Frequency versus time graph of all triggers in the primary channel before this hveto round (dots colored by signal-to-noise ratio) and those triggers that are vetoed by this round (red plusses)."
-round_used_snr = "Signal-to-noise ratio versus time graph of all triggers in the auxiliary channel above the threshold selected for this round (black dots, these are the triggers used to construct the veto) and the primary channel triggers that are vetoed in this round (red plusses). This can indicate whether, for example, louder triggers in the auxiliary channel are used to veto quieter channels in the primary channel, as might be expected for an external disturbance."
-round_aux_snr = "Signal-to-noise ratio versus time graph of all triggers in the auxiliary channel before this round (black dots), those above the threshold selected for this round (yellow plusses, these are the triggers used to construct the veto), and those triggers that actually veto one of the primary channel triggers (red plusses)."
-round_aux_snr_freq = "Signal-to-noise ratio versus frequency graph of all triggers in the auxiliary channel before this round (black dots), those above the threshold selected for this round (yellow plusses, these are the triggers used to construct the veto), and those triggers that actually veto one of the primary channel triggers (red plusses)."
-round_aux_freq = "Frequency versus time graph of all triggers in the auxiliary channel before this round (dots colored by signal-to-noise ratio), those above the threshold selected for this round (yellow plusses, these are the triggers used to construct the veto), and those triggers that actually veto one of the primary channel triggers (red plusses)."
-round_sig_drop = "This plot includes interactive features (channel names appear when pointed to with your mouse cursor) that can be accessed by opening the plot in a new tab. The statistical significance value (based on Poisson statistics) for the best SNR and time window combination for each auxiliary channel before and after this round are shown as a baton. The round’s winning channel, which had the highest significance, is shown in yellow. The top of the yellow baton is the significance of this channel before this round and the bottom of the baton is its significance in the next round, after its triggers above this round’s SNR threshold and time window have been removed (note that this channel may have nonzero significance in the next round because it may still have triggers left at a lower SNR threshold). Blue batons are for channels whose significance dropped after this round (indicating that that channel had some trigger times in common with the winner) and red batons are for channels whose significance increased in the next round (due to less livetime)."
+round_hist = "Histogram of number of triggers in the primary channel before "
+"this round of hveto (red) compared with the number after vetoes from this "
+"round have been applied (blue) versus the signal-to-noise ratio of those "
+"triggers."
+round_snr_time = "Signal-to-noise ratio versus time graph of all triggers in "
+"the primary channel before this round of hveto (black dots) and those "
+"triggers that are vetoed by this round (red plusses)."
+round_snr_freq = "Signal-to-noise ratio versus frequency graph of all "
+"triggers in the primary channel before this round of hveto (black dots) and "
+"those triggers that are vetoed by this round (red plusses)."
+round_freq = "Frequency versus time graph of all triggers in the primary "
+"channel before this hveto round (dots colored by signal-to-noise ratio) and "
+"those triggers that are vetoed by this round (red plusses)."
+round_used_snr = "Signal-to-noise ratio versus time graph of all triggers in "
+"the auxiliary channel above the threshold selected for this round (black "
+"dots, these are the triggers used to construct the veto) and the primary "
+"channel triggers that are vetoed in this round (red plusses). This can "
+"indicate whether, for example, louder triggers in the auxiliary channel are "
+"used to veto quieter channels in the primary channel, as might be expected "
+"for an external disturbance."
+round_aux_snr = "Signal-to-noise ratio versus time graph of all triggers in "
+"the auxiliary channel before this round (black dots), those above the "
+"threshold selected for this round (yellow plusses, these are the triggers "
+"used to construct the veto), and those triggers that actually veto one of the "
+"primary channel triggers (red plusses)."
+round_aux_snr_freq = "Signal-to-noise ratio versus frequency graph of all "
+"triggers in the auxiliary channel before this round (black dots), those above "
+"the threshold selected for this round (yellow plusses, these are the triggers "
+"used to construct the veto), and those triggers that actually veto one of the "
+"primary channel triggers (red plusses)."
+round_aux_freq = "Frequency versus time graph of all triggers in the auxiliary "
+"channel before this round (dots colored by signal-to-noise ratio), those "
+"above the threshold selected for this round (yellow plusses, these are the "
+"triggers used to construct the veto), and those triggers that actually veto "
+"one of the primary channel triggers (red plusses)."
+round_sig_drop = "This plot includes interactive features (channel names "
+"appear when pointed to with your mouse cursor) that can be accessed by "
+"opening the plot in a new tab. The statistical significance value (based on "
+"Poisson statistics) for the best SNR and time window combination for each "
+"auxiliary channel before and after this round are shown as a baton. The "
+"round’s winning channel, which had the highest significance, is shown in "
+"yellow. The top of the yellow baton is the significance of this channel "
+"before this round and the bottom of the baton is its significance in the next "
+"round, after its triggers above this round’s SNR threshold and time window "
+"have been removed (note that this channel may have nonzero significance in "
+"the next round because it may still have triggers left at a lower SNR "
+"threshold). Blue batons are for channels whose significance dropped after "
+"this round (indicating that that channel had some trigger times in common "
+"with the winner) and red batons are for channels whose significance increased "
+"in the next round (due to less livetime)."
 round_captions = [round_hist, round_snr_time, round_snr_freq,
                   round_freq, round_used_snr, round_aux_snr,
                   round_aux_snr_freq, round_aux_freq]
@@ -698,7 +749,7 @@ def write_round(round):
     page.div(class_='row')
     page.div(class_='col-sm-12')
     page.add(fancybox_img(round.plots[-1],
-                          pparams={'title': round_sig_drop}))
+                          linkparams={'title': round_sig_drop}))
     page.div.close()  # col-sm-12
     page.div.close()  # row
     page.div.close()  # col-md-8

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -408,7 +408,7 @@ def fancybox_img(img, linkparams=dict(), **params):
     return str(page)
 
 
-def scaffold_plots(plots, nperrow=2):
+def scaffold_plots(plots, nperrow=2, pparams=dict()):
     """Embed a `list` of images in a bootstrap scaffold
 
     Parameters
@@ -417,6 +417,8 @@ def scaffold_plots(plots, nperrow=2):
         the list of image paths to embed
     nperrow : `int`
         the number of images to place in a row (on a desktop screen)
+    pparams : `dict`
+        a dictionary of image link parameters, indexed by filename
 
     Returns
     -------
@@ -427,10 +429,12 @@ def scaffold_plots(plots, nperrow=2):
     x = int(12//nperrow)
     # scaffold plots
     for i, p in enumerate(plots):
+        if p not in pparams:
+            pparams[p] = dict()
         if i % nperrow == 0:
             page.div(class_='row')
         page.div(class_='col-sm-%d' % x)
-        page.add(fancybox_img(p))
+        page.add(fancybox_img(p, linkparams=pparams[p]))
         page.div.close()  # col
         if i % nperrow == nperrow - 1:
             page.div.close()  # row
@@ -515,7 +519,7 @@ def write_config_html(filepath, format='ini'):
 # -- Hveto HTML ---------------------------------------------------------------
 
 def write_summary(
-        rounds, plots=[], header='Summary', plotsperrow=4,
+        rounds, plots=[], header='Summary', plotsperrow=4, pparams=dict(),
         tableclass='table table-condensed table-hover table-responsive'):
     """Write the Hveto analysis summary HTML
 
@@ -529,6 +533,8 @@ def write_summary(
         the text for the section header (``<h2``>)
     plotsperrow : `int`, optional
         the number of plots to display in each row
+    pparams : `dict`
+        a dictionary of image link parameters, indexed by filename
     tableclass : `str`, optional
         the ``class`` for the summary ``<table>``
 
@@ -584,17 +590,19 @@ def write_summary(
 
     # scaffold plots
     if plots:
-        page.add(scaffold_plots(plots, nperrow=plotsperrow))
+        page.add(scaffold_plots(plots, nperrow=plotsperrow, pparams=pparams))
     return page()
 
 
-def write_round(round):
+def write_round(round, pparams=dict()):
     """Write the HTML summary for a specific round
 
     Parameters
     ----------
     round : `HvetoRound`
         the analysis round object
+    pparams : `dict`
+        a dictionary of image link parameters, indexed by filename
 
     Returns
     -------
@@ -658,7 +666,7 @@ def write_round(round):
     page.div.close()  # col
     # plots
     page.div(class_='col-md-9', id_='hveto-round-%d-plots' % round.n)
-    page.add(scaffold_plots(round.plots[:-1], nperrow=4))
+    page.add(scaffold_plots(round.plots[:-1], nperrow=4, pparams=pparams))
     # add significance drop plot at end
     page.div(class_='row')
     page.div(class_='col-sm-12')

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -498,7 +498,7 @@ def fancybox_img(img, linkparams=dict(), **params):
     return str(page)
 
 
-def scaffold_plots(plots, nperrow=2, pparams=dict()):
+def scaffold_plots(plots, nperrow=2, figparams=dict()):
     """Embed a `list` of images in a bootstrap scaffold
 
     Parameters
@@ -507,7 +507,7 @@ def scaffold_plots(plots, nperrow=2, pparams=dict()):
         the list of image paths to embed
     nperrow : `int`
         the number of images to place in a row (on a desktop screen)
-    pparams : `dict`
+    figparams : `dict`
         a dictionary of image link parameters, indexed by filename
 
     Returns
@@ -519,12 +519,12 @@ def scaffold_plots(plots, nperrow=2, pparams=dict()):
     x = int(12//nperrow)
     # scaffold plots
     for i, p in enumerate(plots):
-        if p not in pparams:
-            pparams[p] = dict()
+        if p not in figparams:
+            figparams[p] = dict()
         if i % nperrow == 0:
             page.div(class_='row')
         page.div(class_='col-sm-%d' % x)
-        page.add(fancybox_img(p, linkparams=pparams[p]))
+        page.add(fancybox_img(p, linkparams=figparams[p]))
         page.div.close()  # col
         if i % nperrow == nperrow - 1:
             page.div.close()  # row
@@ -681,7 +681,7 @@ def write_summary(
         pparams = dict()
         for i, p in enumerate(plots):
             pparams[p] = {'title': HEADER_CAPTIONS[i]}
-        page.add(scaffold_plots(plots, nperrow=plotsperrow, pparams=pparams))
+        page.add(scaffold_plots(plots, nperrow=plotsperrow, figparams=pparams))
     return page()
 
 
@@ -758,7 +758,7 @@ def write_round(round):
     pparams = dict()
     for i, p in enumerate(round.plots[:-1]):
         pparams[p] = {'title': ROUND_CAPTIONS[i]}
-    page.add(scaffold_plots(round.plots[:-1], nperrow=4, pparams=pparams))
+    page.add(scaffold_plots(round.plots[:-1], nperrow=4, figparams=pparams))
     # add significance drop plot at end
     page.div(class_='row')
     page.div(class_='col-sm-12')

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -21,6 +21,7 @@
 
 from __future__ import division
 
+import os.path
 import warnings
 from math import (log10, floor)
 from io import BytesIO
@@ -35,7 +36,7 @@ from gwpy.plotter import (HistogramPlot, EventTablePlot,
 from gwpy.plotter.table import get_column_string
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-__credits__ = 'Josh Smith, Joe Areeda'
+__credits__ = 'Josh Smith, Joe Areeda, Alex Urban'
 
 rcParams.update({
     'figure.subplot.bottom': 0.17,
@@ -73,6 +74,112 @@ SHOW_HIDE_JAVASCRIPT = """
     ]]>
     </script>"""
 
+
+# -- set up default header plot captions
+
+HEADER_CAPTION = {
+    'HISTOGRAM':
+    "Histogram of number of triggers in the primary channel before the hveto "
+    "analysis, but after the data quality flag cuts (red) compared with the "
+    "number after vetoes from all hveto rounds have been applied (blue) "
+    "versus the signal-to-noise ratio of those triggers.",
+    'ROC':
+    "The fraction of the primary channel triggers vetoed (fractional "
+    "efficiency) versus the fraction of livetime that is vetoed (fractional "
+    "deadtime) for each hveto round (blue dots). Guidelines are given for "
+    "efficiency/deadtime of 1 (the value expected for random chance) and "
+    "higher.",
+    'TIME':
+     "Frequency versus time graph of all triggers in the primary channel "
+    "before the hveto analysis (black dots) and those triggers that are "
+    "vetoed by a given round (symbols).",
+    'SNR_TIME':
+    "Signal-to-noise ratio versus time graph of all triggers in the primary "
+    "channel before the hveto analysis (black dots) and those triggers that "
+    "are vetoed by a given round (symbols)."
+}
+
+
+# -- set up default round winner plot captions
+
+ROUND_CAPTION = {
+    'HISTOGRAM':
+    "Histogram of number of triggers in the primary channel before this round "
+    "of hveto (red) compared with the number after vetoes from this round "
+    "have been applied (blue) versus the signal-to-noise ratio of those "
+    "triggers.",
+    'SNR_TIME':
+    "Signal-to-noise ratio versus time graph of all triggers in the primary "
+    "channel before this round of hveto (black dots) and those triggers that "
+    "are vetoed by this round (red plusses).",
+    'SNR':
+    "Signal-to-noise ratio versus frequency graph of all triggers in the "
+    "primary channel before this round of hveto (black dots) and those "
+    "triggers that are vetoed by this round (red plusses).",
+    'TIME':
+    "Frequency versus time graph of all triggers in the primary channel "
+    "before this hveto round (dots colored by signal-to-noise ratio) and "
+    "those triggers that are vetoed by this round (red plusses).",
+    'USED_SNR_TIME':
+    "Signal-to-noise ratio versus time graph of all triggers in the auxiliary "
+    "channel above the threshold selected for this round (black dots, these "
+    "are the triggers used to construct the veto) and the primary channel "
+    "triggers that are vetoed in this round (red plusses). This can indicate "
+    "whether, for example, louder triggers in the auxiliary channel are used "
+    "to veto quieter channels in the primary channel, as might be expected "
+    "for an external disturbance.",
+    'AUX_SNR_TIME':
+    "Signal-to-noise ratio versus time graph of all triggers in the auxiliary "
+    "channel before this round (black dots), those above the threshold "
+    "selected for this round (yellow plusses, these are the triggers used to "
+    "construct the veto), and those triggers that actually veto one of the "
+    "primary channel triggers (red plusses).",
+    'AUX_SNR_FREQUENCY':
+    "Signal-to-noise ratio versus frequency graph of all triggers in the "
+    "auxiliary channel before this round (black dots), those above the "
+    "threshold selected for this round (yellow plusses, these are the "
+    "triggers used to construct the veto), and those triggers that actually "
+    "veto one of the primary channel triggers (red plusses).",
+    'AUX_FREQUENCY_TIME':
+    "Frequency versus time graph of all triggers in the auxiliary channel "
+    "before this round (dots colored by signal-to-noise ratio), those above "
+    "the threshold selected for this round (yellow plusses, these are the "
+    "triggers used to construct the veto), and those triggers that actually "
+    "veto one of the primary channel triggers (red plusses).",
+    'SIG_DROP':
+    "This plot includes interactive features (channel "
+    "names appear when pointed to with your mouse cursor) that can be "
+    "accessed by opening the plot in a new tab. The statistical "
+    "significance value (based on Poisson statistics) for the best SNR and "
+    "time window combination for each auxiliary channel before and after "
+    "this round are shown as a baton. The round’s winning channel, which "
+    "had the highest significance, is shown in yellow. The top of the "
+    "yellow baton is the significance of this channel before this round and "
+    "the bottom of the baton is its significance in the next round, after "
+    "its triggers above this round’s SNR threshold and time window have "
+    "been removed (note that this channel may have nonzero significance in "
+    "the next round because it may still have triggers left at a lower SNR "
+    "threshold). Blue batons are for channels whose significance dropped "
+    "after this round (indicating that that channel had some trigger times "
+    "in common with the winner) and red batons are for channels whose "
+    "significance increased in the next round (due to less livetime)."
+}
+
+
+# -- Plot construction --------------------------------------------------------
+
+class FancyPlot(object):
+    def __init__(self, img, caption=None):
+        if isinstance(img, FancyPlot):
+            caption = caption if caption else img.caption
+        self.img = str(img)
+        self.caption = caption if caption else os.path.basename(self.img)
+
+    def __str__(self):
+        return self.img
+
+
+# -- Functions ----------------------------------------------------------------
 
 def before_after_histogram(
         outfile, x, y, label1='Before', label2='After',

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -171,6 +171,23 @@ ROUND_CAPTION = {
 # -- Plot construction --------------------------------------------------------
 
 class FancyPlot(object):
+    """A helpful class of objects that coalesce image links and caption text
+    for fancybox figures.
+
+    Parameters
+    ----------
+    img : `str` or `FancyPlot`
+        either a filename (including relative or absolute path) or another
+        FancyPlot instance
+    caption : `str`
+        the text to be displayed in a fancybox as this figure's caption
+
+    Examples
+    --------
+    >>> from hveto.plot import FancyPlot
+    >>> example = FancyPlot('plot.png')
+    >>> print example.img, example.caption
+    """
     def __init__(self, img, caption=None):
         if isinstance(img, FancyPlot):
             caption = caption if caption else img.caption

--- a/hveto/plot.py
+++ b/hveto/plot.py
@@ -79,24 +79,24 @@ SHOW_HIDE_JAVASCRIPT = """
 
 HEADER_CAPTION = {
     'HISTOGRAM':
-    "Histogram of number of triggers in the primary channel before the hveto "
-    "analysis, but after the data quality flag cuts (red) compared with the "
-    "number after vetoes from all hveto rounds have been applied (blue) "
-    "versus the signal-to-noise ratio of those triggers.",
+        "Histogram of number of triggers in the primary channel before the "
+        "heveto analysis, but after the data quality flag cuts (red) compared "
+        "with the number after vetoes from all hveto rounds have been applied "
+        "(blue) versus the signal-to-noise ratio of those triggers.",
     'ROC':
-    "The fraction of the primary channel triggers vetoed (fractional "
-    "efficiency) versus the fraction of livetime that is vetoed (fractional "
-    "deadtime) for each hveto round (blue dots). Guidelines are given for "
-    "efficiency/deadtime of 1 (the value expected for random chance) and "
-    "higher.",
+        "The fraction of the primary channel triggers vetoed (fractional "
+        "efficiency) versus the fraction of livetime that is vetoed "
+        "(fractional deadtime) for each hveto round (blue dots). Guidelines "
+        "are given for efficiency/deadtime of 1 (the value expected for "
+        "random chance) and higher.",
     'TIME':
-     "Frequency versus time graph of all triggers in the primary channel "
-    "before the hveto analysis (black dots) and those triggers that are "
-    "vetoed by a given round (symbols).",
+        "Frequency versus time graph of all triggers in the primary channel "
+        "before the hveto analysis (black dots) and those triggers that are "
+        "vetoed by a given round (symbols).",
     'SNR_TIME':
-    "Signal-to-noise ratio versus time graph of all triggers in the primary "
-    "channel before the hveto analysis (black dots) and those triggers that "
-    "are vetoed by a given round (symbols)."
+        "Signal-to-noise ratio versus time graph of all triggers in the "
+        "primary channel before the hveto analysis (black dots) and those "
+        "triggers that are vetoed by a given round (symbols)."
 }
 
 
@@ -104,65 +104,67 @@ HEADER_CAPTION = {
 
 ROUND_CAPTION = {
     'HISTOGRAM':
-    "Histogram of number of triggers in the primary channel before this round "
-    "of hveto (red) compared with the number after vetoes from this round "
-    "have been applied (blue) versus the signal-to-noise ratio of those "
-    "triggers.",
+        "Histogram of number of triggers in the primary channel before this "
+        "round of hveto (red) compared with the number after vetoes from this "
+        "round have been applied (blue) versus the signal-to-noise ratio of "
+        "those triggers.",
     'SNR_TIME':
-    "Signal-to-noise ratio versus time graph of all triggers in the primary "
-    "channel before this round of hveto (black dots) and those triggers that "
-    "are vetoed by this round (red plusses).",
+        "Signal-to-noise ratio versus time graph of all triggers in the "
+        "primary channel before this round of hveto (black dots) and those "
+        "triggers that are vetoed by this round (red plusses).",
     'SNR':
-    "Signal-to-noise ratio versus frequency graph of all triggers in the "
-    "primary channel before this round of hveto (black dots) and those "
-    "triggers that are vetoed by this round (red plusses).",
+        "Signal-to-noise ratio versus frequency graph of all triggers in the "
+        "primary channel before this round of hveto (black dots) and those "
+        "triggers that are vetoed by this round (red plusses).",
     'TIME':
-    "Frequency versus time graph of all triggers in the primary channel "
-    "before this hveto round (dots colored by signal-to-noise ratio) and "
-    "those triggers that are vetoed by this round (red plusses).",
+        "Frequency versus time graph of all triggers in the primary channel "
+        "before this hveto round (dots colored by signal-to-noise ratio) and "
+        "those triggers that are vetoed by this round (red plusses).",
     'USED_SNR_TIME':
-    "Signal-to-noise ratio versus time graph of all triggers in the auxiliary "
-    "channel above the threshold selected for this round (black dots, these "
-    "are the triggers used to construct the veto) and the primary channel "
-    "triggers that are vetoed in this round (red plusses). This can indicate "
-    "whether, for example, louder triggers in the auxiliary channel are used "
-    "to veto quieter channels in the primary channel, as might be expected "
-    "for an external disturbance.",
+        "Signal-to-noise ratio versus time graph of all triggers in the "
+        "auxiliary channel above the threshold selected for this round (black "
+        "dots, these are the triggers used to construct the veto) and the "
+        "primary channel triggers that are vetoed in this round (red "
+        "plusses). This can indicate whether, for example, louder triggers in "
+        "the auxiliary channel are used to veto quieter channels in the "
+        "primary channel, as might be expected for an external disturbance.",
     'AUX_SNR_TIME':
-    "Signal-to-noise ratio versus time graph of all triggers in the auxiliary "
-    "channel before this round (black dots), those above the threshold "
-    "selected for this round (yellow plusses, these are the triggers used to "
-    "construct the veto), and those triggers that actually veto one of the "
-    "primary channel triggers (red plusses).",
+        "Signal-to-noise ratio versus time graph of all triggers in the "
+        "auxiliary channel before this round (black dots), those above the "
+        "threshold selected for this round (yellow plusses, these are the "
+        "triggers used to construct the veto), and those triggers that "
+        "actually veto one of the primary channel triggers (red plusses).",
     'AUX_SNR_FREQUENCY':
-    "Signal-to-noise ratio versus frequency graph of all triggers in the "
-    "auxiliary channel before this round (black dots), those above the "
-    "threshold selected for this round (yellow plusses, these are the "
-    "triggers used to construct the veto), and those triggers that actually "
-    "veto one of the primary channel triggers (red plusses).",
+        "Signal-to-noise ratio versus frequency graph of all triggers in the "
+        "auxiliary channel before this round (black dots), those above the "
+        "threshold selected for this round (yellow plusses, these are the "
+        "triggers used to construct the veto), and those triggers that "
+        "actually veto one of the primary channel triggers (red plusses).",
     'AUX_FREQUENCY_TIME':
-    "Frequency versus time graph of all triggers in the auxiliary channel "
-    "before this round (dots colored by signal-to-noise ratio), those above "
-    "the threshold selected for this round (yellow plusses, these are the "
-    "triggers used to construct the veto), and those triggers that actually "
-    "veto one of the primary channel triggers (red plusses).",
+        "Frequency versus time graph of all triggers in the auxiliary channel "
+        "before this round (dots colored by signal-to-noise ratio), those "
+        "above the threshold selected for this round (yellow plusses, these "
+        "are the triggers used to construct the veto), and those triggers "
+        "that actually veto one of the primary channel triggers (red "
+        "plusses).",
     'SIG_DROP':
-    "This plot includes interactive features (channel "
-    "names appear when pointed to with your mouse cursor) that can be "
-    "accessed by opening the plot in a new tab. The statistical "
-    "significance value (based on Poisson statistics) for the best SNR and "
-    "time window combination for each auxiliary channel before and after "
-    "this round are shown as a baton. The round’s winning channel, which "
-    "had the highest significance, is shown in yellow. The top of the "
-    "yellow baton is the significance of this channel before this round and "
-    "the bottom of the baton is its significance in the next round, after "
-    "its triggers above this round’s SNR threshold and time window have "
-    "been removed (note that this channel may have nonzero significance in "
-    "the next round because it may still have triggers left at a lower SNR "
-    "threshold). Blue batons are for channels whose significance dropped "
-    "after this round (indicating that that channel had some trigger times "
-    "in common with the winner) and red batons are for channels whose "
-    "significance increased in the next round (due to less livetime)."
+        "This plot includes interactive features (channel names appear when "
+        "pointed to with your mouse cursor) that can be accessed by opening "
+        "the plot in a new tab. The statistical significance value (based on "
+        "Poisson statistics) for the best SNR and time window combination for "
+        "each auxiliary channel before and after this round are shown as a "
+        "baton. The round’s winning channel, which had the highest "
+        "significance, is shown in yellow. The top of the yellow baton is the "
+        "significance of this channel before this round and the bottom of the "
+        "baton is its significance in the next round, after its triggers "
+        "above this round’s SNR threshold and time window have been removed "
+        "(note that this channel may have nonzero significance in the next "
+        "round because it may still have triggers left at a lower SNR "
+        "threshold). Blue batons are for channels whose significance dropped "
+        "after this round (indicating that that channel had some trigger "
+        "times in common with the winner) and red batons are for channels "
+        "whose significance increased in the next round (due to less "
+        "livetime)."
 }
 
 

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -27,8 +27,11 @@ import datetime
 from getpass import getuser
 
 from hveto import html
-from hveto.plot import FancyPlot
 from hveto._version import get_versions
+
+from matplotlib import use
+use('agg')  # nopep8
+from hveto.plot import FancyPlot
 
 from common import unittest
 

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -27,6 +27,7 @@ import datetime
 from getpass import getuser
 
 from hveto import html
+from hveto.plot import FancyPlot
 from hveto._version import get_versions
 
 from common import unittest
@@ -149,7 +150,8 @@ class HtmlTestCase(unittest.TestCase):
                  'X1:TEST-CHANNEL">X1:TEST-CHANNEL</a>')
 
     def test_fancybox_img(self):
-        out = html.fancybox_img('test.png')
+        img = FancyPlot('test.png')
+        out = html.fancybox_img(img)
         self.assertEqual(
             out, '<a class="fancybox" href="test.png" target="_blank" '
                  'data-fancybox-group="hveto-image" title="test.png">\n'
@@ -157,7 +159,8 @@ class HtmlTestCase(unittest.TestCase):
                  '\n</a>')
 
     def test_scaffold_plots(self):
-        out = html.scaffold_plots(['plot1.png', 'plot2.png'])
+        out = html.scaffold_plots([FancyPlot('plot1.png'),
+                                   FancyPlot('plot2.png')])
         self.assertEqual(
             out, '<div class="row">\n'
                  '<div class="col-sm-6">\n'

--- a/hveto/tests/test_plot.py
+++ b/hveto/tests/test_plot.py
@@ -53,3 +53,8 @@ class PlotTestCase(unittest.TestCase):
             finally:
                 if os.path.isfile(svg):
                     os.remove(svg)
+
+    def test_fancy_plot(self):
+        test = plot.FancyPlot('test.png')
+        assert test.img is 'test.png'
+        assert test.caption is 'test.png'

--- a/hveto/tests/test_plot.py
+++ b/hveto/tests/test_plot.py
@@ -55,6 +55,12 @@ class PlotTestCase(unittest.TestCase):
                     os.remove(svg)
 
     def test_fancy_plot(self):
+        # create a dummy FancyPlot instance
         test = plot.FancyPlot('test.png')
+        assert test.img is 'test.png'
+        assert test.caption is 'test.png'
+        # check that its properties are unchanged when the argument
+        # to FancyPlot() is also a FancyPlot instance
+        test = plot.FancyPlot(test)
         assert test.img is 'test.png'
         assert test.caption is 'test.png'


### PR DESCRIPTION
On the Hveto page that is linked from the summary pages, there is a standing request to add figure captions more descriptive than simply the filename of the figure. This PR addresses that request by hard-coding a few caption drafts written up by Josh Smith and company (see https://docs.google.com/document/d/1yb4COW4KKvAzc2nf15a7t_JtproD1SUVzyAjA8x95QA).

This fixes #80.