### PR TITLE
Add support for GWpy 4.0.0

### DIFF
--- a/hveto/cli/trace.py
+++ b/hveto/cli/trace.py
@@ -107,7 +107,10 @@ def main(args=None):
             lambda f_name: '.txt' in f_name,
             cround[u'files'][u'VETO_SEGS'])
         for f in seg_files:
-            segments = SegmentList.read(os.path.join(args.directory, f))
+            segments = SegmentList.read(
+                os.path.join(args.directory, f),
+                format="segwizard",
+            )
             if time in segments:
                 segment = segments[segments.find(time)]
                 logger.info('Trigger time {0} was vetoed in round {1} by '

--- a/hveto/html.py
+++ b/hveto/html.py
@@ -91,7 +91,9 @@ def banner(ifo, start, end):
     page.h1("%s HierarchicalVeto" % ifo, class_='pb-2 mt-3 mb-2 border-bottom')
 
     td = timedelta(seconds=(end - start))
-    page.h3(f"{start} - {end} {tconvert(start)} - {tconvert(end)} -- {td}", class_='mt-3')
+    startstr = tconvert(start).strftime('%Y-%m-%d %H:%M:%S')
+    endstr = tconvert(end).strftime('%Y-%m-%d %H:%M:%S')
+    page.h3(f"{start} - {end} {startstr} - {endstr} -- {td}", class_='mt-3')
     page.div.close()
     return page()
 

--- a/hveto/segments.py
+++ b/hveto/segments.py
@@ -62,6 +62,8 @@ def write_ascii(outfile, segmentlist, ncol=4):
     if ncol not in [2, 4]:
         raise ValueError("Invalid number of columns: %r" % ncol)
     with open(outfile, 'w') as f:
+        if ncol == 4:
+            print("# seg\tstart\tstop\tduration", file=f)
         for i, seg in enumerate(segmentlist):
             if ncol == 2:
                 print("%f %f" % seg, file=f)

--- a/hveto/tests/test_html.py
+++ b/hveto/tests/test_html.py
@@ -21,6 +21,7 @@
 
 import os
 import shutil
+from unittest import mock
 
 import pytest
 
@@ -96,7 +97,14 @@ def test_bold_param(args, kwargs, result):
 
 # -- end-to-end tests ---------------------------------------------------------
 
-def test_write_hveto_page(tmpdir):
+@mock.patch(
+    "gwdetchar.io.html.package_list",
+    return_value=[
+        {"name": "package-1", "version": "1.0.0"},
+        {"name": "package-2", "version": "2.0.0"},
+    ],
+)
+def test_write_hveto_page(mock_package_list, tmpdir):
     os.chdir(str(tmpdir))
     config = 'test.ini'
     with open(config, 'w') as fobj:

--- a/hveto/tests/test_segments.py
+++ b/hveto/tests/test_segments.py
@@ -60,7 +60,7 @@ def test_write_segments_ascii(ncol, tmpdir):
     outdir = str(tmpdir)
     out = os.path.join(outdir, 'test.txt')
     segments.write_ascii(out, TEST_SEGMENTS, ncol=ncol)
-    a = SegmentList.read(out, gpstype=float, strict=False)
+    a = SegmentList.read(out, gpstype=float, strict=False, format="segwizard")
     assert a == TEST_SEGMENTS_2
     # clean up
     shutil.rmtree(outdir, ignore_errors=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 # requirements
 requires-python = ">=3.10"
 dependencies = [
+  "astropy >=5.0",
   "gwdetchar >= 2.3.2",
   "gwpy >=2.0.0",
   "gwtrigfind >= 0.8.3",


### PR DESCRIPTION
GWpy 4.0.0rc1 has been released, and includes a number of breaking changes that impact this project. This PR includes patches to fix the test suite when installed alongside the new GWpy.

I have not tested an actual Hveto run, so there could easily be more to fix.