### PR TITLE
Use uv to manage the environment for CI/CD jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 # -----------------------
 #
 # Run a full build-and-test from the git repo
-# using a combination of conda and pip to install
-# all optional dependencies.
+# using uv to install all dependencies.
 #
 # This is the 'full' test suite.
 #
@@ -25,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  conda:
-    name: Conda Python ${{ matrix.python-version }} (${{ matrix.os }})
+  test:
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
 
     strategy:
       fail-fast: false
@@ -39,80 +38,47 @@ jobs:
           - "3.11"
     runs-on: ${{ matrix.os }}-latest
 
-    # this is needed for conda environments to activate automatically
-    defaults:
-      run:
-        shell: bash -el {0}
-
     steps:
     - name: Get source code
       uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
-    - name: Cache conda packages
-      uses: actions/cache@v4
-      env:
-        # increment to reset cache
-        CACHE_NUMBER: 0
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
       with:
-        path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ env.CACHE_NUMBER }}
-        restore-keys: ${{ runner.os }}-conda-${{ matrix.python-version }}-
-
-    - name: Configure conda
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        auto-update-conda: true
-        miniforge-version: latest
         python-version: ${{ matrix.python-version }}
 
-    - name: Conda info
-      run: conda info --all
-
-    - name: Install dependencies with conda
-      run: |
-        # parse requirements to install as much as possible with conda
-        mamba create --name pip2conda pip2conda
-        mamba run -n pip2conda pip2conda \
-            --all \
-            --output environment.txt \
-            --python-version ${{ matrix.python-version }}
-        echo "-----------------"
-        cat environment.txt
-        echo "-----------------"
-        mamba install --quiet --yes --name test --file environment.txt
-
-    - name: Install HVeto
-      run: python -m pip install .[test] --no-build-isolation -vv
+    - name: Install the project
+      run: uv sync --all-extras --dev
 
     - name: Package list
-      run: conda list --name test
+      run: uv pip list
 
     - name: Run test suite
-      run: python -m pytest -ra --color yes --cov hveto --pyargs hveto.tests --junitxml=pytest.xml
+      run: uv run -m pytest -ra --color yes --cov hveto --pyargs hveto.tests --junitxml=pytest.xml
 
     - name: Sanity check entry points
       run: |
-        python -m coverage run --append --source hveto -m hveto --help
-        python -m coverage run --append --source hveto -m hveto.cli.cache_events --help
-        python -m coverage run --append --source hveto -m hveto.cli.trace --help
+        uv run -m coverage run --append --source hveto -m hveto --help
+        uv run -m coverage run --append --source hveto -m hveto.cli.cache_events --help
+        uv run -m coverage run --append --source hveto -m hveto.cli.trace --help
 
     - name: Coverage report
-      run: python -m coverage report --show-missing
+      run: uv run -m coverage report --show-missing
 
     - name: Prepare codecov upload
-      run: python -m coverage xml
+      run: uv run -m coverage xml
 
     - name: Publish coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
         files: coverage.xml
-        flags: Conda,${{ runner.os }},python${{ matrix.python-version }}
+        flags: ${{ runner.os }},python${{ matrix.python-version }}
 
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v5
       with:
-        name: pytest-conda-${{ matrix.os }}-${{ matrix.python-version }}
+        name: pytest-${{ matrix.os }}-${{ matrix.python-version }}
         path: pytest.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dynamic = [
 # test suite
 test = [
   "coverage[toml]",
+  "pip",
   "pytest >=3.1.0",
   "pytest-cov >=2.4.0",
 ]


### PR DESCRIPTION
This PR updates (simplifies?) the CI/CD pipeline to use `uv` to manage dependencies in the test workflow. This is simpler than using conda and pip2conda, and should yield the same results (roughly).