### PR TITLE
Add CI/CD test jobs for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
         python-version:
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
     runs-on: ${{ matrix.os }}-latest
 
     # this is needed for conda environments to activate automatically


### PR DESCRIPTION
This PR updates the CI/CD workflow to test against Python 3.12 and 3.13.

Depends: #183 